### PR TITLE
Add ah_build module

### DIFF
--- a/plugins/module_utils/ah_module.py
+++ b/plugins/module_utils/ah_module.py
@@ -768,7 +768,8 @@ class AHModule(AnsibleModule):
                 to_text(output_path, errors='surrogate_or_strict'),
                 force,
             )
-            self.json_output["path"] = out
+            # path output is correct in ansible-galaxy >= 2.10.0 but in earlier versions the value is not returned so we can just return the output_path
+            self.json_output["path"] = out or output_path
             self.json_output["changed"] = True
             self.exit_json(**self.json_output)
         except Exception as e:

--- a/plugins/module_utils/ah_module.py
+++ b/plugins/module_utils/ah_module.py
@@ -11,6 +11,7 @@ from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.http_cookiejar import CookieJar
 from ansible.galaxy.collection import build_collection
 from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.compat.importlib import import_module  # noqa F401
 import os.path
 from socket import gethostbyname
 import re

--- a/plugins/module_utils/ah_module.py
+++ b/plugins/module_utils/ah_module.py
@@ -11,7 +11,6 @@ from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.http_cookiejar import CookieJar
 from ansible.galaxy.collection import build_collection
 from ansible.module_utils._text import to_bytes, to_native, to_text
-from ansible.module_utils.compat.importlib import import_module
 import os.path
 from socket import gethostbyname
 import re
@@ -755,7 +754,7 @@ class AHModule(AnsibleModule):
     def execute_build(self, path, force, output_path):
         path = self._resolve_path(path)
         output_path = self._resolve_path(output_path)
-        b_output_path = to_bytes(output_path, errors='surrogate_or_strict')
+        b_output_path = to_bytes(output_path, errors="surrogate_or_strict")
 
         if not os.path.exists(b_output_path):
             os.makedirs(b_output_path)
@@ -764,8 +763,8 @@ class AHModule(AnsibleModule):
 
         try:
             out = build_collection(
-                to_text(path, errors='surrogate_or_strict'),
-                to_text(output_path, errors='surrogate_or_strict'),
+                to_text(path, errors="surrogate_or_strict"),
+                to_text(output_path, errors="surrogate_or_strict"),
                 force,
             )
             # path output is correct in ansible-galaxy >= 2.10.0 but in earlier versions the value is not returned so we can just return the output_path

--- a/plugins/modules/ah_approval.py
+++ b/plugins/modules/ah_approval.py
@@ -52,6 +52,7 @@ EXAMPLES = """
 
 from ..module_utils.ah_module import AHModule
 
+
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
@@ -68,7 +69,7 @@ def main():
     name = module.params.get("name")
     version = module.params.get("version")
 
-    endpoint="collections/{0}/{1}/versions/{2}".format(namespace, name, version)
+    endpoint = "collections/{0}/{1}/versions/{2}".format(namespace, name, version)
 
     # Attempt to look up an existing item based on the provided data
     existing_item = module.get_endpoint(endpoint, **{"return_none_on_404": True})
@@ -80,6 +81,7 @@ def main():
     module.approve(
         endpoint=endpoint,
     )
+
 
 if __name__ == "__main__":
     main()

--- a/plugins/modules/ah_build.py
+++ b/plugins/modules/ah_build.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# (c) 2020, Tom Page <@Tompage1994>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {"metadata_version": "1.1", "status": ["preview"], "supported_by": "community"}
+
+
+DOCUMENTATION = """
+---
+module: ah_build
+author: "Tom Page (@Tompage1994)"
+short_description: Build a collection tar.
+description:
+    - Build a collection tar ready for Automation Hub. See
+      U(https://www.ansible.com/) for an overview.
+requirements:
+  - "ansible-galaxy >= 2.10.0"
+options:
+    path:
+      description:
+        - Path to the collection(s) directory to build. This should be the directory that contains the galaxy.yml file. The default is the current working directory.
+      required: True
+      type: str
+    force:
+      description:
+        - Whether to force the build to take place.
+      required: False
+      type: str
+      default: false
+    output_path:
+      description:
+        - he path in which the collection is built to. The default is the current working directory.
+      required: False
+      type: str
+      default: "."
+
+"""
+
+
+EXAMPLES = """
+- name: Approve redhat_cop.ah_configuration:v1.0.0
+  ah_approval:
+    path: /path/to/collection
+    force: true
+    output_path: /var/tmp
+
+"""
+
+from ..module_utils.ah_module import AHModule
+
+def main():
+    # Any additional arguments that are not fields of the item can be added here
+    argument_spec = dict(
+        path=dict(required=True),
+        force=dict(type="bool"),
+        output_path=dict(required=False, default=".")
+    )
+
+    # Create a module for ourselves
+    module = AHModule(argument_spec=argument_spec, require_auth=False)
+
+    # Extract our parameters
+    path = module.params.get("path")
+    force = module.params.get("force")
+    output_path = module.params.get("output_path")
+
+    module.execute_build(path, force, output_path)
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/ah_build.py
+++ b/plugins/modules/ah_build.py
@@ -20,8 +20,6 @@ short_description: Build a collection tar.
 description:
     - Build a collection tar ready for Automation Hub. See
       U(https://www.ansible.com/) for an overview.
-requirements:
-  - "ansible-galaxy >= 2.10.0"
 options:
     path:
       description:

--- a/plugins/modules/ah_build.py
+++ b/plugins/modules/ah_build.py
@@ -46,9 +46,9 @@ options:
 
 
 EXAMPLES = """
-- name: Approve redhat_cop.ah_configuration:v1.0.0
-  ah_approval:
-    path: /path/to/collection
+- name: Build redhat_cop.ah_configuration:v1.0.0
+  ah_build:
+    path: /home/ansible/ah_configuration
     force: true
     output_path: /var/tmp
 

--- a/plugins/modules/ah_build.py
+++ b/plugins/modules/ah_build.py
@@ -23,7 +23,9 @@ description:
 options:
     path:
       description:
-        - Path to the collection(s) directory to build. This should be the directory that contains the galaxy.yml file. The default is the current working directory.
+        - Path to the collection(s) directory to build.
+          This should be the directory that contains the galaxy.yml file.
+          The default is the current working directory.
       required: False
       type: str
       default: "."

--- a/plugins/modules/ah_build.py
+++ b/plugins/modules/ah_build.py
@@ -54,13 +54,10 @@ EXAMPLES = """
 
 from ..module_utils.ah_module import AHModule
 
+
 def main():
     # Any additional arguments that are not fields of the item can be added here
-    argument_spec = dict(
-        path=dict(required=False, default="."),
-        force=dict(type="bool"),
-        output_path=dict(required=False, default=".")
-    )
+    argument_spec = dict(path=dict(required=False, default="."), force=dict(type="bool"), output_path=dict(required=False, default="."))
 
     # Create a module for ourselves
     module = AHModule(argument_spec=argument_spec, require_auth=False)
@@ -71,6 +68,7 @@ def main():
     output_path = module.params.get("output_path")
 
     module.execute_build(path, force, output_path)
+
 
 if __name__ == "__main__":
     main()

--- a/plugins/modules/ah_build.py
+++ b/plugins/modules/ah_build.py
@@ -24,8 +24,9 @@ options:
     path:
       description:
         - Path to the collection(s) directory to build. This should be the directory that contains the galaxy.yml file. The default is the current working directory.
-      required: True
+      required: False
       type: str
+      default: "."
     force:
       description:
         - Whether to force the build to take place.
@@ -56,7 +57,7 @@ from ..module_utils.ah_module import AHModule
 def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
-        path=dict(required=True),
+        path=dict(required=False, default="."),
         force=dict(type="bool"),
         output_path=dict(required=False, default=".")
     )


### PR DESCRIPTION
### What does this PR do?
Adds a module to run an ansible-galaxy build. It pulls from the ansible modules which are used to run the ansible-galaxy CLI. 

### How should this be tested?
Try using 

```
ansible -m redhat_cop.ah_configuration.ah_build localhost -c local [-a "force=true path=/path/to/collection output_path=/path/to/out"]
```

instead of 

```
ansible-galaxy collection install [-f --output-path /path/to/out /path/to/collection]
```

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
Linting will fail until #19 is merged. Please merge that first
