### PR TITLE
Fix ah_repository module for when no requirements are specified

### DIFF
--- a/changelogs/fragments/repository_fix.yml
+++ b/changelogs/fragments/repository_fix.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixes issue in ah_repository where not specifying a requirements list causedd a failure.
+...

--- a/playbooks/testing_playbook.yml
+++ b/playbooks/testing_playbook.yml
@@ -57,4 +57,11 @@
         requirements:
           - name: redhat_cop.ah_configuration
           - name: redhat_cop.tower_configuration
+
+    - name: Configure community repo
+      ah_repository:
+        name: rh-certified
+        url: https://cloud.redhat.com/api/automation-hub/
+        auth_url: https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token
+        token: aabbcc
 ...

--- a/plugins/modules/ah_repository.py
+++ b/plugins/modules/ah_repository.py
@@ -114,11 +114,12 @@ def main():
 
     # Extract our parameters
     name = module.params.get("name")
-    requirements = module.params.get("requirements")
-
-    requirements_file = "\n  - ".join(requirements)
     new_fields = {}
-    new_fields["requirements_file"] = "---\ncollections:\n  - " + requirements_file
+
+    requirements = module.params.get("requirements")
+    if requirements:
+        requirements_file = "\n  - ".join(requirements)
+        new_fields["requirements_file"] = "---\ncollections:\n  - " + requirements_file
 
     for field_name in (
         "url",


### PR DESCRIPTION
### What does this PR do?
Fix to the ah_repository module where not specifying a requirements file caused a module error.

### How should this be tested?
CI would now catch such an error (if it were working...)

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A
