### PR TITLE
fixed typo in README data structure example

### DIFF
--- a/roles/namespace/README.md
+++ b/roles/namespace/README.md
@@ -58,7 +58,7 @@ ah_configuration_namespace_secure_logging defaults to the value of ah_configurat
 #### Ymal Example
 ```yaml
 ---
-ah_namespace:
+ah_namespaces:
   - name: abc15
     company: Redhat
     email: user@example.com


### PR DESCRIPTION
fixed typo in README data structure example from 'ah_namespace' to 'ah_namespaces'

