### PR TITLE
retry approvals if failed as there can be a slight delay

### DIFF
--- a/changelogs/fragments/publish_approval_retry.yml
+++ b/changelogs/fragments/publish_approval_retry.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Now retries auto-approving on the publish role in case there is a delay in the collection making it to be ready for approval.
+...

--- a/roles/publish/tasks/main.yml
+++ b/roles/publish/tasks/main.yml
@@ -95,6 +95,9 @@
     loop_var: "__ah_collection_file"
   no_log: "{{ ah_configuration_publish_secure_logging }}"
   when: ah_auto_approve
-
+  register: approval
+  retries: 3
+  delay: 2
+  until: not approval is failed
 
 ...


### PR DESCRIPTION
### What does this PR do?
retries approvals on the publish role if failed as there can be a slight delay. I've seen this come up a few times and running the role again works and have seen the collection waiting for approval so must be caused by the delay of the collection making it to be ready for approval.

