### PR TITLE
Add ability to use requirements file for repo

### DIFF
--- a/playbooks/collection_requirement_file.yml
+++ b/playbooks/collection_requirement_file.yml
@@ -1,0 +1,5 @@
+---
+- name: redhat_cop.ah_configuration
+- name: redhat_cop.tower_configuration
+- name: ansible.windows
+...

--- a/playbooks/testing_playbook.yml
+++ b/playbooks/testing_playbook.yml
@@ -58,6 +58,12 @@
           - name: redhat_cop.ah_configuration
           - name: redhat_cop.tower_configuration
 
+    - name: Configure community repo from file
+      ah_repository:
+        name: community
+        url: https://galaxy.ansible.com/api/
+        requirements_file: collection_requirement_file.yml
+
     - name: Sync community repo
       ah_repository_sync:
         name: community

--- a/plugins/module_utils/ah_module.py
+++ b/plugins/module_utils/ah_module.py
@@ -613,6 +613,11 @@ class AHModule(AnsibleModule):
 
         return (parser(headers)["content-type"], b_content)  # Message converts to native strings
 
+    def getFileContent(self, path):
+        with open(to_bytes(path, errors="surrogate_or_strict"), "rb") as f:
+            b_file_data = f.read()
+        return to_text(b_file_data)
+
     def upload(self, path, endpoint, auto_exit=True, item_type="unknown"):
         ct, body = self.prepare_multipart(path)
         response = self.make_request("POST", endpoint, **{"data": body, "headers": {"Content-Type": str(ct)}, "binary": True, "return_errors_on_404": True})


### PR DESCRIPTION
### What does this PR do?
Allows the use of `requirement_file` option which allows using a file rather than specifying the requirements in-line

### How should this be tested?
Added a task to the testing playbook (although its currently broken)

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #25 

### Other Relevant info, PRs, etc.
N/A
