### PR TITLE
fix: set no_log for passwd fields

### DIFF
--- a/changelogs/fragments/changes.yml
+++ b/changelogs/fragments/changes.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Add the `no_log` attribute to the `password` and `proxy_password` fields
+    of the `ah_repository` module (Resolves #47).

--- a/plugins/modules/ah_repository.py
+++ b/plugins/modules/ah_repository.py
@@ -111,12 +111,12 @@ def main():
         auth_url=dict(),
         token=dict(),
         username=dict(),
-        password=dict(),
+        password=dict(no_log=True),
         requirements=dict(type="list", elements="str"),
         requirements_file=dict(),
         proxy_url=dict(),
         proxy_username=dict(),
-        proxy_password=dict(),
+        proxy_password=dict(no_log=True),
         download_concurrency=dict(default="10"),
     )
 


### PR DESCRIPTION
### What does this PR do?
Sets the `no_log` parameter for password fields of the `ah_repository` module. 

### How should this be tested?
When you use the `ah_repository` module, you should not see the Warning messages (as shown in #47), but instead:

![image](https://user-images.githubusercontent.com/10145457/133633940-47f25def-78cf-4094-a203-3d8287c7e849.png)



### Is there a relevant Issue open for this?
This resolves #47 

### Other Relevant info, PRs, etc.
- none