### PR TITLE
Adding a `new_name' parameter to the ah_ee_namespace and ah_ee_repository modules

### DIFF
--- a/changelogs/fragments/49-ee-new-name.yml
+++ b/changelogs/fragments/49-ee-new-name.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - ah_ee_namespace and ah_ee_repository - adding the ``new_name`` parameter
+    so that users can rename namespaces and repositories
+    (https://github.com/redhat-cop/ah_configuration/issues/44)

--- a/playbooks/testing_playbook_ee_namespace.yml
+++ b/playbooks/testing_playbook_ee_namespace.yml
@@ -109,16 +109,37 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
         validate_certs: "{{ ah_validate_certs }}"
 
-    # Testing namespace deletion
-    - name: Ensure namespace1 EE namespace does not exist
+    # Testing namespace renaming
+    - name: Ensure namespace1 has a new name (namespace2)
       ah_ee_namespace:
         name: namespace1
-        state: absent
+        new_name: namespace2
+        state: present
+        append: true
+        groups:
+          - administrators
         ah_host: "{{ ah_host }}"
         ah_username: "{{ ah_username }}"
         ah_password: "{{ ah_password }}"
         ah_path_prefix: "{{ ah_path_prefix }}"
         validate_certs: "{{ ah_validate_certs }}"
+
+    # Testing namespace deletion
+    - name: Ensure namespace1 EE namespace does not exist
+      ah_ee_namespace:
+        name: "{{ item }}"
+        state: absent
+        # new_name is ignored when deleting the namespace (state: absent)
+        new_name: foobar
+        ah_host: "{{ ah_host }}"
+        ah_username: "{{ ah_username }}"
+        ah_password: "{{ ah_password }}"
+        ah_path_prefix: "{{ ah_path_prefix }}"
+        validate_certs: "{{ ah_validate_certs }}"
+      loop:
+        # namespace1 should not exist (renamed by a preceding task)
+        - namespace1
+        - namespace2
 
     - name: Ensure the groups are deleted
       ah_group:

--- a/playbooks/testing_playbook_ee_repository.yml
+++ b/playbooks/testing_playbook_ee_repository.yml
@@ -12,7 +12,7 @@
     ah_password: redhat
     ah_path_prefix: galaxy
     ah_validate_certs: false
-    repository: ansible-automation-platform-20-early-access/ee-minimal-rhel8
+    repository: test-namespace/ee-minimal-rhel8
     tag: latest
     fake_image: quay.io/ansible/http-test-container:latest
 
@@ -83,6 +83,60 @@
     - name: Ensure the repository README file it set from a local file
       ah_ee_repository:
         name: "{{ repository }}"
+        readme_file: "{{ tempfile['path'] }}"
+        state: updated
+        ah_host: "{{ ah_host }}"
+        ah_username: "{{ ah_username }}"
+        ah_password: "{{ ah_password }}"
+        ah_path_prefix: "{{ ah_path_prefix }}"
+        validate_certs: "{{ ah_validate_certs }}"
+
+    # Testing renaming
+    - name: Ensure the repository is renamed
+      ah_ee_repository:
+        name: "{{ repository }}"
+        new_name: test-namespace-rename/image
+        delete_namespace_if_empty: false
+        description: Repository renamed
+        readme: Repository renamed
+        state: updated
+        ah_host: "{{ ah_host }}"
+        ah_username: "{{ ah_username }}"
+        ah_password: "{{ ah_password }}"
+        ah_path_prefix: "{{ ah_path_prefix }}"
+        validate_certs: "{{ ah_validate_certs }}"
+
+    - name: Ensure the repository is renamed in the same namespace
+      ah_ee_repository:
+        name: test-namespace-rename/image
+        new_name: test-namespace-rename/image2
+        description: Repository renamed
+        readme: Repository renamed
+        state: updated
+        ah_host: "{{ ah_host }}"
+        ah_username: "{{ ah_username }}"
+        ah_password: "{{ ah_password }}"
+        ah_path_prefix: "{{ ah_path_prefix }}"
+        validate_certs: "{{ ah_validate_certs }}"
+
+    - name: Ensure the repository is renamed with no explicit namespace name
+      ah_ee_repository:
+        name: test-namespace-rename/image2
+        new_name: test-namespace-image
+        description: Repository renamed
+        readme: Repository renamed
+        state: updated
+        ah_host: "{{ ah_host }}"
+        ah_username: "{{ ah_username }}"
+        ah_password: "{{ ah_password }}"
+        ah_path_prefix: "{{ ah_path_prefix }}"
+        validate_certs: "{{ ah_validate_certs }}"
+
+    - name: Ensure the repository is renamed back to its original name
+      ah_ee_repository:
+        name: test-namespace-image
+        new_name: "{{ repository }}"
+        description: To jest jakiś opis
         readme_file: "{{ tempfile['path'] }}"
         state: updated
         ah_host: "{{ ah_host }}"


### PR DESCRIPTION
### What does this PR do?

The PR adds a `new_name` parameter to the `ah_ee_namespace` and `ah_ee_repository` modules.
Users can use that parameter to rename execution environment namespaces and repositories.

The `new_name` parameter has *not* been added to the `ah_ee_image` module because images do not have names, they have a SHA256 digest.

### How should this be tested?

The `playbooks/testing_playbook_ee_namespace.yml` and `playbooks/testing_playbook_ee_repository.yml` playbooks have been updated to include tests for this `new_name` parameter.

### Is there a relevant Issue open for this?

Resolves #44 
 