### PR TITLE
Add 'wait' option on ah_collection_upload

### DIFF
--- a/plugins/modules/ah_collection_upload.py
+++ b/plugins/modules/ah_collection_upload.py
@@ -26,6 +26,11 @@ options:
         - Collection artifact file path.
       required: True
       type: str
+    wait
+      description:
+        - Waits for the collection to be uploaded
+      type: bool
+      default: true
 
 extends_documentation_fragment: redhat_cop.ah_configuration.auth
 """
@@ -45,6 +50,7 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         path=dict(required=True),
+        wait=dict(type="bool", default=True),
     )
 
     # Create a module for ourselves
@@ -52,9 +58,9 @@ def main():
 
     # Extract our parameters
     path = module.params.get("path")
+    wait = module.params.get("wait")
 
-    module.upload(path, "artifacts/collections", item_type="collections")
-
+    module.upload(path, "artifacts/collections", wait, item_type="collections")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### What does this PR do?
Added option to wait for upload to complete and displays error messages if there are any

### How should this be tested?
```
    - name: Upload collection to automation hub
      redhat_cop.ah_configuration.ah_collection_upload:
        path: ns-col-0.0.1.tar.gz
        wait: true
```

Run on valid collection twice. First will pass, second will fail with correct error message

### Is there a relevant Issue open for this?
resolves #52 - Error messages now show when wait is set to true

### Other Relevant info, PRs, etc.
N/A
