### PR TITLE
added new group permisions

### DIFF
--- a/changelogs/fragments/new_ah_perms.yml
+++ b/changelogs/fragments/new_ah_perms.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - added new permision options to the ah_group_perm module and group role.

--- a/changelogs/fragments/new_ah_perms.yml
+++ b/changelogs/fragments/new_ah_perms.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
   - added new permision options to the ah_group_perm module and group role.
+  - added namespace state absent module parameter

--- a/plugins/module_utils/ah_module.py
+++ b/plugins/module_utils/ah_module.py
@@ -391,8 +391,9 @@ class AHModule(AnsibleModule):
         #   1. None if the existing_item is not defined (so no delete needs to happen)
         #   2. The response from Automation Hub from calling the delete on the endpont. It's up to you to process the response and exit from the module
         # Note: common error codes from the Automation Hub API can cause the module to fail
-        if existing_item["type"] == "token":
-            response = self.delete_endpoint(existing_item["endpoint"])
+        if existing_item:
+            if existing_item["type"] == "token":
+                response = self.delete_endpoint(existing_item["endpoint"])
         elif existing_item:
             # If we have an item, we can try to delete it
             try:

--- a/plugins/modules/ah_group_perm.py
+++ b/plugins/modules/ah_group_perm.py
@@ -119,7 +119,7 @@ FRIENDLY_PERM_NAMES = {
     "add_namespace": "galaxy.add_namespace",
     "change_namespace": "galaxy.change_namespace",
     "upload_to_namespace": "galaxy.upload_to_namespace",
-    "delete_namespace":	"galaxy.delete_namespace",
+    "delete_namespace": "galaxy.delete_namespace",
     # Collections
     "modify_ansible_repo_content": "ansible.modify_ansible_repo_content",
     "delete_collection": "ansible.delete_collection",

--- a/plugins/modules/ah_group_perm.py
+++ b/plugins/modules/ah_group_perm.py
@@ -33,12 +33,13 @@ options:
       - The module accepts the following roles.
       - For user management, C(add_user), C(change_user), C(delete_user), and C(view_user).
       - For group management, C(add_group), C(change_group), C("delete_group"), and C(view_group).
-      - For collection namespace management, C(add_namespace), C(change_namespace), and C(upload_to_namespace).
-      - For collection content management, C(modify_ansible_repo_content)
-      - For remote repository configuration, C(change_collectionremote) and C(view_collectionremote).
+      - For collection namespace management, C(add_namespace), C(change_namespace), C(upload_to_namespace), and C(delete_namespace).
+      - For collection content management, C(modify_ansible_repo_content), and C(delete_collection).
+      - For remote repository configuration, C(change_collectionremote), and C(view_collectionremote).
       - For container image management, only with private automation hub v4.3.2
         or later, C(change_containernamespace_perms), C(change_container),
-        C(change_image_tag), C(create_container), and C(push_container).
+        C(change_image_tag), C(create_container), and C(push_container), and C(delete_containerrepository).
+      - For task management, C(change_task), C(view_task), and C(delete_task).
       - You can also grant or revoke all permissions with C(*) or C(all).
     type: list
     elements: str
@@ -118,8 +119,10 @@ FRIENDLY_PERM_NAMES = {
     "add_namespace": "galaxy.add_namespace",
     "change_namespace": "galaxy.change_namespace",
     "upload_to_namespace": "galaxy.upload_to_namespace",
+    "delete_namespace":	"galaxy.delete_namespace",
     # Collections
     "modify_ansible_repo_content": "ansible.modify_ansible_repo_content",
+    "delete_collection": "ansible.delete_collection",
     # Users
     "add_user": "galaxy.add_user",
     "change_user": "galaxy.change_user",
@@ -139,6 +142,11 @@ FRIENDLY_PERM_NAMES = {
     "change_image_tag": "container.namespace_modify_content_containerpushrepository",
     "create_container": "container.add_containernamespace",
     "push_container": "container.namespace_push_containerdistribution",
+    "delete_containerrepository": "container.delete_containerrepository",
+    # Tasks
+    "change_task": "core.change_task",
+    "delete_task": "core.delete_task",
+    "view_task": "core.view_task",
 }
 
 

--- a/plugins/modules/ah_namespace.py
+++ b/plugins/modules/ah_namespace.py
@@ -53,8 +53,7 @@ options:
     state:
       description:
         - Desired state of the resource.
-        - Currently the ability to delete objects in Automation Hub is not available, this option is included for when it is.
-      choices: ["present"]
+      choices: ["present", "absent"]
       default: "present"
       type: str
     links:
@@ -76,8 +75,8 @@ options:
     groups:
       description:
         - A list of dictionaries of the Names and object_permissions values for groups that control the Namespace.
+        - Required if state is present
       type: list
-      required: True
       elements: dict
       suboptions:
         name:
@@ -129,8 +128,8 @@ def main():
         avatar_url=dict(),
         resources=dict(),
         links=dict(type="list", elements="dict"),
-        groups=dict(required=True, type="list", elements="dict"),
-        state=dict(choices=["present"], default="present"),
+        groups=dict(type="list", elements="dict"),
+        state=dict(choices=["present", "absent"], default="present"),
     )
 
     # Create a module for ourselves

--- a/roles/group/README.md
+++ b/roles/group/README.md
@@ -40,12 +40,13 @@ ah_configuration_group_secure_logging defaults to the value of ah_configuration_
 The module accepts the following roles:
 - For user management, `add_user`, `change_user`, `delete_user`, and `view_user`.
 - For group management, `add_group`, `change_group`, `delete_group`, and `view_group`.
-- For collection namespace management, `add_namespace`, `change_namespace`, and `upload_to_namespace`.
-- For collection content management, `modify_ansible_repo_content`
+- For collection namespace management, `add_namespace`, `change_namespace`, `upload_to_namespace`, and `delete_namespace`.
+- For collection content management, `modify_ansible_repo_content`, and `delete_collection`.
 - For remote repository configuration, `change_collectionremote` and `view_collectionremote`.
 - For container image management, only with private automation hub v4.3.2
   or later, `change_containernamespace_perms`, `change_container`,
-  `change_image_tag`, `create_container`, and `push_container`.
+  `change_image_tag`, `create_container`, `push_container`, and `delete_containerrepository`.
+- For task management, `change_task`, `view_task`, and `delete_task`.
 - You can also grant or revoke all permissions with `*` or `all`.
 
 ### Standard Project Data Structure


### PR DESCRIPTION
### What does this PR do?
New Group permissions were added in the latest version of Automation Hub, added them as options
Also added the ability to delete namespaces using state: absent
Made change to existing item for delete to check that existing item exists, should mimic what works in[ awx.awx](https://github.com/ansible/awx/blob/60b6faff1963fb03cfdaa95c73a367fdae9f60b6/awx_collection/plugins/module_utils/controller_api.py#L637) 
