### PR TITLE
Add ability to use remote path

### DIFF
--- a/plugins/module_utils/ah_module.py
+++ b/plugins/module_utils/ah_module.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
-from ansible.module_utils.urls import Request, SSLValidationError, ConnectionError
+from ansible.module_utils.urls import Request, SSLValidationError, ConnectionError, fetch_file
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six import PY2, PY3
 from ansible.module_utils.six.moves.urllib.parse import urlparse, urlencode
@@ -633,6 +633,11 @@ class AHModule(AnsibleModule):
             self.exit_json(**self.json_output)
 
     def upload(self, path, endpoint, wait=True, item_type="unknown"):
+        if "://" in path:
+            tmppath = fetch_file(self, path)
+            path = ".".join(tmppath.split(".")[:-2]) + ".tar.gz"
+            os.rename(tmppath, path)
+            self.add_cleanup_file(path)
         ct, body = self.prepare_multipart(path)
         response = self.make_request("POST", endpoint, **{"data": body, "headers": {"Content-Type": str(ct)}, "binary": True, "return_errors_on_404": True})
         if response["status_code"] in [202]:

--- a/plugins/modules/ah_collection_upload.py
+++ b/plugins/modules/ah_collection_upload.py
@@ -24,6 +24,7 @@ options:
     path:
       description:
         - Collection artifact file path.
+        - Can be a URL
       required: True
       type: str
     wait:
@@ -40,6 +41,10 @@ EXAMPLES = """
 - name: Upload collection to automation hub
   ah_collection_upload:
     path: /var/tmp/collections/awx_awx-15.0.0.tar.gz
+
+- name: Upload collection to automation hub from galaxy
+  ah_collection_upload:
+    path: https://galaxy.ansible.com/download/theforeman-foreman-3.2.0.tar.gz
 
 """
 


### PR DESCRIPTION
### What does this PR do?
Adds ability to use a remote path for a collection

### How should this be tested?
```
- redhat_cop.ah_configuration.ah_collection_upload:
        path: https://galaxy.ansible.com/download/theforeman-foreman-3.0.0.tar.gz
```

### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #57

### Other Relevant info, PRs, etc.
@sean-m-sullivan Your PR #61 will want to pull in this change (it shouldn't conflict I think) and then you'll just need to add a line in the option of `path` that it accepts URLs