### PR TITLE
Add permission definitions for the `Remote Registries` category.

### DIFF
--- a/plugins/modules/ah_group_perm.py
+++ b/plugins/modules/ah_group_perm.py
@@ -39,6 +39,7 @@ options:
       - For container image management, only with private automation hub v4.3.2
         or later, C(change_containernamespace_perms), C(change_container),
         C(change_image_tag), C(create_container), and C(push_container), and C(delete_containerrepository).
+      - For remote registry management, C(add_containerregistryremote), C(change_containerregistryremote), and C(delete_containerregistryremote).
       - For task management, C(change_task), C(view_task), and C(delete_task).
       - You can also grant or revoke all permissions with C(*) or C(all).
     type: list

--- a/plugins/modules/ah_group_perm.py
+++ b/plugins/modules/ah_group_perm.py
@@ -143,6 +143,10 @@ FRIENDLY_PERM_NAMES = {
     "create_container": "container.add_containernamespace",
     "push_container": "container.namespace_push_containerdistribution",
     "delete_containerrepository": "container.delete_containerrepository",
+    # Remote Registries
+    "add_containerregistryremote": "galaxy.add_containerregistryremote",
+    "change_containerregistryremote": "galaxy.change_containerregistryremote",
+    "delete_containerregistryremote": "galaxy.delete_containerregistryremote",
     # Tasks
     "change_task": "core.change_task",
     "delete_task": "core.delete_task",


### PR DESCRIPTION
### What does this PR do?
While using the `ah_group_perm` module, I realized that it did not provide the ability to create permissions in the `Remote Registries` category. I found that those permissions were missing from `FRIENDLY_PERM_NAMES` in the `ah_group_perms.py` file. Maybe my choices for "friendly perm names" could be even friendlier?

### How should this be tested?
Because I did not know the names of the permissions, I added a group using the web UI and added all of the remote registry permissions. 
* You can then query the API to identify the group ID: https:// hub.example.com/api/galaxy/_ui/v1/groups/
* Using the group ID (XX), you can query the permissions: https://hub.example.com/api/galaxy/_ui/v1/groups/XX/model-permissions/

The changes in this PR can be tested with the following tasks:
```
- name: Add remote registry permissions                                              
  redhat_cop.ah_configuration.ah_group_perm:                                    
    name: operators                                                             
    perms:                                                                      
      - add_containerregistryremote                                             
      - change_containerregistryremote                                           
      - delete_containerregistryremote                                           
    state: present                                                              
    ah_host: hub.example.com                                                    
    ah_username: admin                                                          
    ah_password: Sup3r53cr3t                                                    
                                                                                
- name: Remove remote registry permissions                                      
  redhat_cop.ah_configuration.ah_group_perm:                                    
    name: operators                                                             
    perms:                                                                      
      - add_containerregistryremote                                             
      - change_containerregistryremote                                          
      - delete_containerregistryremote                                          
    state: absent                                                               
    ah_host: hub.example.com                                                    
    ah_username: admin                                                          
    ah_password: Sup3r53cr3t
```

### Is there a relevant Issue open for this?
No.

### Other Relevant info, PRs, etc.
N.A.
