### PR TITLE
Add error checking around 400 responses when a genuine error

### DIFF
--- a/changelogs/fragments/response.yml
+++ b/changelogs/fragments/response.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed an issue where a genuine API error would cause a module to have an unhandled error.
+...

--- a/plugins/module_utils/ah_api_module.py
+++ b/plugins/module_utils/ah_api_module.py
@@ -206,10 +206,10 @@ class AHAPIModule(AnsibleModule):
                 # We are going to return a 400 so the module can decide what to do with it
                 page_data = he.read()
                 try:
-                    return {'status_code': he.code, 'json': json.loads(page_data)}
+                    return {"status_code": he.code, "json": json.loads(page_data)}
                 # JSONDecodeError only available on Python 3.5+
                 except ValueError:
-                    return {'status_code': he.code, 'text': page_data}
+                    return {"status_code": he.code, "text": page_data}
             elif he.code == 204 and method == "DELETE":
                 # A 204 is a normal response for a delete function
                 pass

--- a/plugins/module_utils/ah_api_module.py
+++ b/plugins/module_utils/ah_api_module.py
@@ -204,7 +204,12 @@ class AHAPIModule(AnsibleModule):
             # Sanity check: Did we get some other kind of error?  If so, write an appropriate error message.
             elif he.code >= 400:
                 # We are going to return a 400 so the module can decide what to do with it
-                pass
+                page_data = he.read()
+                try:
+                    return {'status_code': he.code, 'json': json.loads(page_data)}
+                # JSONDecodeError only available on Python 3.5+
+                except ValueError:
+                    return {'status_code': he.code, 'text': page_data}
             elif he.code == 204 and method == "DELETE":
                 # A 204 is a normal response for a delete function
                 pass
@@ -239,6 +244,10 @@ class AHAPIModule(AnsibleModule):
         try:
             response_body = response.read()
         except Exception as e:
+            if response["json"]["errors"]:
+                raise AHAPIModuleError("Errors occurred with request (HTTP 400). Errors: {errors}".format(errors=response["json"]["errors"]))
+            elif response["text"]:
+                raise AHAPIModuleError("Errors occurred with request (HTTP 400). Errors: {errors}".format(errors=response["text"]))
             raise AHAPIModuleError("Failed to read response body: {error}".format(error=e))
 
         response_json = {}


### PR DESCRIPTION
### What does this PR do?
Add error checking around 400 responses when a genuine error comes ck from the API

I found an issue when trying to create a user and setting the password to `password`. The API complains that the password is too short and cant be a common word but the module just errors out because `response.read()` fails. Instead I've taken inspiration for what is done in `awx.awx` and just take that error and set it to response so that once the `response.read()` does fail it can display the error from the API

### How should this be tested?
Fails out previously with 

```
- redhat_cop.ah_configuration.ah_user:
        username:         "myneweruser"
        password:         "password"
```
but now fails out but displays the error message.

Setting 
```
- redhat_cop.ah_configuration.ah_user:
        username:         "myneweruser"
        password:         "p@@ssword"
```
will work.

### Is there a relevant Issue open for this?
N/A

### Other Relevant info, PRs, etc.
N/A