### PR TITLE
Fix bug where namespace module complained of groups not set

### DIFF
--- a/changelogs/fragments/ah_namespace_group.yml
+++ b/changelogs/fragments/ah_namespace_group.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed issue where groups was required to create a namespace using ah_namespace module
+...

--- a/plugins/modules/ah_namespace.py
+++ b/plugins/modules/ah_namespace.py
@@ -75,9 +75,9 @@ options:
     groups:
       description:
         - A list of dictionaries of the Names and object_permissions values for groups that control the Namespace.
-        - Required if state is present
       type: list
       elements: dict
+      default: []
       suboptions:
         name:
           description:

--- a/plugins/modules/ah_namespace.py
+++ b/plugins/modules/ah_namespace.py
@@ -128,7 +128,7 @@ def main():
         avatar_url=dict(),
         resources=dict(),
         links=dict(type="list", elements="dict"),
-        groups=dict(type="list", elements="dict"),
+        groups=dict(type="list", elements="dict", default=[]),
         state=dict(choices=["present", "absent"], default="present"),
     )
 


### PR DESCRIPTION
### What does this PR do?
Fixes issue with ah_namespace module not working unless setting `groups`

### How should this be tested?
```
- name: Create NS
      redhat_cop.ah_configuration.ah_namespace:
        name: testns1
```
will now work where it didn't before

### Is there a relevant Issue open for this?
resolves #112 

