### PR TITLE
Add several options to ah_ee_registry

### DIFF
--- a/changelogs/fragments/ee_registry_options.yml
+++ b/changelogs/fragments/ee_registry_options.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Added certificate and key authentication for ee registries in ah_ee_registry module
+...

--- a/plugins/module_utils/ah_api_module.py
+++ b/plugins/module_utils/ah_api_module.py
@@ -390,9 +390,12 @@ class AHAPIModule(AnsibleModule):
         self.authenticated = True
 
     def getFileContent(self, path):
-        with open(to_bytes(path, errors="surrogate_or_strict"), "rb") as f:
-            b_file_data = f.read()
-        return to_text(b_file_data)
+        try:
+            with open(to_bytes(path, errors="surrogate_or_strict"), "rb") as f:
+                b_file_data = f.read()
+            return to_text(b_file_data)
+        except FileNotFoundError:
+            self.fail_json(msg="No such file found on the local filesystem: '{}'".format(path))
 
     def logout(self):
         if not self.authenticated:

--- a/plugins/module_utils/ah_api_module.py
+++ b/plugins/module_utils/ah_api_module.py
@@ -16,6 +16,7 @@ import json
 import time
 
 from ansible.module_utils.basic import AnsibleModule, env_fallback
+from ansible.module_utils._text import to_bytes, to_text
 
 from ansible.module_utils.six.moves.urllib.parse import urlparse, urlencode
 from ansible.module_utils.six.moves.urllib.error import HTTPError
@@ -387,6 +388,11 @@ class AHAPIModule(AnsibleModule):
             header = {}
         self.headers.update(header)
         self.authenticated = True
+
+    def getFileContent(self, path):
+        with open(to_bytes(path, errors="surrogate_or_strict"), "rb") as f:
+            b_file_data = f.read()
+        return to_text(b_file_data)
 
     def logout(self):
         if not self.authenticated:


### PR DESCRIPTION
### What does this PR do?
Added cert options for ah_ee_registry

### How should this be tested?
```
- name: Add a remote registry to AH
      redhat_cop.ah_configuration.ah_ee_registry:
        name: my_quayio
        state: present
        url: https://quay.io/my/registry
        ca_cert_path: <path to a pem file>
        client_key_path: <path to a pem file>
        client_cert_path: <path to a pem file>
```
also
```
- name: Add a remote registry to AH
      redhat_cop.ah_configuration.ah_ee_registry:
        name: my_quayio
        state: present
        url: https://quay.io/my/registry
        ca_cert: "{{ lookup('file','cert.pem') }}"
        client_key: "{{ lookup('file','key.pem') }}"
        client_cert: "<value of a pem file>"
```
### Is there a relevant Issue open for this?
None

### Other Relevant info, PRs, etc.
Found in follow up to #119 and #120 
