### PR TITLE
Add exception catching on getFileContent

### DIFF
--- a/plugins/module_utils/ah_module.py
+++ b/plugins/module_utils/ah_module.py
@@ -610,9 +610,12 @@ class AHModule(AnsibleModule):
         return (parser(headers)["content-type"], b_content)  # Message converts to native strings
 
     def getFileContent(self, path):
-        with open(to_bytes(path, errors="surrogate_or_strict"), "rb") as f:
-            b_file_data = f.read()
-        return to_text(b_file_data)
+        try:
+            with open(to_bytes(path, errors="surrogate_or_strict"), "rb") as f:
+                b_file_data = f.read()
+            return to_text(b_file_data)
+        except FileNotFoundError:
+            self.fail_json(msg="No such file found on the local filesystem: '{}'".format(path))
 
     def wait_for_complete(self, task_url):
         endpoint = task_url


### PR DESCRIPTION
### What does this PR do?
Catches FileNotFoundError and gives proper error message

### How should this be tested?
```
- name: Configure community repo
      redhat_cop.ah_configuration.ah_repository:
        name: community
        url: https://galaxy.ansible.com/api/
        requirements_file: fakefile.yml  # file doesn't exist
```

before: Gave a stack trace

after: 
```
TASK [Configure community repo] ***************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "No such file found on the local filesystem:: 'fakefile.yml'"}
```


### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.
resolves #122 

### Other Relevant info, PRs, etc.
N/A
