### PR TITLE
added ah_token to repository_sync role

### DIFF
--- a/changelogs/fragments/collection.yml
+++ b/changelogs/fragments/collection.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - created a role from ah_collection module
+  - add `ah_token` so repository_sync works with token only and doesn't change the original token that happens when using `ah_username` and `ah_password`. This will keep it from breaking Ansible Automation Controller credentials that point to Private Automation Hub.
 ...

--- a/changelogs/fragments/collection.yml
+++ b/changelogs/fragments/collection.yml
@@ -1,4 +1,5 @@
 ---
 minor_changes:
-  - add `ah_token` so repository_sync works with token only and doesn't change the original token that happens when using `ah_username` and `ah_password`. This will keep it from breaking Ansible Automation Controller credentials that point to Private Automation Hub.
+  - created a role from ah_collection module
+  - add `ah_token` so `repository_sync` that was missing
 ...

--- a/roles/repository_sync/tasks/main.yml
+++ b/roles/repository_sync/tasks/main.yml
@@ -8,6 +8,7 @@
     ah_host:        "{{ ah_host | default(ah_hostname) }}"
     ah_username:    "{{ ah_username | default(omit) }}"
     ah_password:    "{{ ah_password | default(omit) }}"
+    ah_token:       "{{ ah_token    | default(omit) }}"
     ah_path_prefix: "{{ ah_path_prefix | default(omit) }}"
     ah_verify_ssl:  "{{ ah_validate_certs | default(omit) }}"
   when: _ah_repositories != []


### PR DESCRIPTION
### What does this PR do?
added the `ah_token` to the `repository_sync` role `tasks/main.yml`, that was missing.  When reading the example in the README.md for the role and in the `tasks/main` itself, it mentions using `ah_token`.  If you use `ah_token` it will not reload a new token in the Private Automation Hub for the `admin` or any other user account.  This will allow prevent reload of a token that will break job templates and projects in Ansible Automation Hub because the token was changed. 

### How should this be tested?
We're just adding the missing variable that was omitted from the original code.  Adding the `ah_token:` to the `ah_auth.yml` in the `ah_config` directory with the current token should allow this role to run as intended originally per the original example.

### Is there a relevant Issue open for this?
n/a, just fixed it.

### Other Relevant info, PRs, etc.
n/a
