### PR TITLE
added missing ah_token option

### DIFF
--- a/roles/ee_image/tasks/main.yml
+++ b/roles/ee_image/tasks/main.yml
@@ -12,6 +12,7 @@
     ah_username:      "{{ ah_username | default(omit) }}"
     ah_password:      "{{ ah_password | default(omit) }}"
     ah_path_prefix:   "{{ ah_path_prefix | default(omit) }}"
+    ah_token:         "{{ ah_token | default(omit) }}"
     validate_certs:   "{{ ah_validate_certs | default(omit) }}"
   loop: "{{ ah_ee_images }}"
   loop_control:

--- a/roles/ee_namespace/tasks/main.yml
+++ b/roles/ee_namespace/tasks/main.yml
@@ -11,6 +11,7 @@
     ah_host:          "{{ ah_host | default(ah_hostname) }}"
     ah_username:      "{{ ah_username | default(omit) }}"
     ah_password:      "{{ ah_password | default(omit) }}"
+    ah_token:         "{{ ah_token | default(omit) }}"
     ah_path_prefix:   "{{ ah_path_prefix | default(omit) }}"
     validate_certs:   "{{ ah_validate_certs | default(omit) }}"
   loop: "{{ ah_ee_namespaces }}"

--- a/roles/ee_registry/tasks/main.yml
+++ b/roles/ee_registry/tasks/main.yml
@@ -18,6 +18,7 @@
     ah_host:                "{{ ah_host | default(ah_hostname) }}"
     ah_username:            "{{ ah_username | default(omit) }}"
     ah_password:            "{{ ah_password | default(omit) }}"
+    ah_token:               "{{ ah_token | default(omit) }}"
     ah_path_prefix:         "{{ ah_path_prefix | default(omit) }}"
     validate_certs:         "{{ ah_validate_certs | default(omit) }}"
   loop: "{{ ah_ee_registries }}"

--- a/roles/ee_registry_index/tasks/main.yml
+++ b/roles/ee_registry_index/tasks/main.yml
@@ -11,6 +11,7 @@
     ah_username:            "{{ ah_username | default(omit) }}"
     ah_password:            "{{ ah_password | default(omit) }}"
     ah_path_prefix:         "{{ ah_path_prefix | default(omit) }}"
+    ah_token:               "{{ ah_token | default(omit) }}"
     validate_certs:         "{{ ah_validate_certs | default(omit) }}"
   loop: "{{ ah_ee_registries }}"
   loop_control:

--- a/roles/ee_registry_sync/tasks/main.yml
+++ b/roles/ee_registry_sync/tasks/main.yml
@@ -10,6 +10,7 @@
     ah_host:                "{{ ah_host | default(ah_hostname) }}"
     ah_username:            "{{ ah_username | default(omit) }}"
     ah_password:            "{{ ah_password | default(omit) }}"
+    ah_token:               "{{ ah_token | default(omit) }}"
     ah_path_prefix:         "{{ ah_path_prefix | default(omit) }}"
     validate_certs:         "{{ ah_validate_certs | default(omit) }}"
   loop: "{{ ah_ee_registries }}"

--- a/roles/ee_repository/tasks/main.yml
+++ b/roles/ee_repository/tasks/main.yml
@@ -17,6 +17,7 @@
     ah_host:                    "{{ ah_host | default(ah_hostname) }}"
     ah_username:                "{{ ah_username | default(omit) }}"
     ah_password:                "{{ ah_password | default(omit) }}"
+    ah_token:                   "{{ ah_token | default(omit) }}"
     ah_path_prefix:             "{{ ah_path_prefix | default(omit) }}"
     validate_certs:             "{{ ah_validate_certs | default(omit) }}"
   loop: "{{ ah_ee_repositories }}"

--- a/roles/ee_repository_sync/tasks/main.yml
+++ b/roles/ee_repository_sync/tasks/main.yml
@@ -10,6 +10,7 @@
     ah_host:                "{{ ah_host | default(ah_hostname) }}"
     ah_username:            "{{ ah_username | default(omit) }}"
     ah_password:            "{{ ah_password | default(omit) }}"
+    ah_token:               "{{ ah_token | default(omit) }}"
     ah_path_prefix:         "{{ ah_path_prefix | default(omit) }}"
     validate_certs:         "{{ ah_validate_certs | default(omit) }}"
   loop: "{{ ah_ee_repositories }}"

--- a/roles/group/tasks/main.yml
+++ b/roles/group/tasks/main.yml
@@ -9,6 +9,7 @@
     ah_host:          "{{ ah_host | default(ah_hostname) }}"
     ah_username:      "{{ ah_username | default(omit) }}"
     ah_password:      "{{ ah_password | default(omit) }}"
+    ah_token:         "{{ ah_token | default(omit) }}"
     ah_path_prefix:   "{{ ah_path_prefix | default(omit) }}"
     validate_certs:   "{{ ah_validate_certs | default(omit) }}"
   loop: "{{ ah_groups }}"

--- a/roles/repository/README.md
+++ b/roles/repository/README.md
@@ -20,6 +20,7 @@ These are the sub options for the vars `ah_repository_certified` and `ah_reposit
 |`proxy_url`|""|no|Proxy URL to use for the connection.||
 |`proxy_username`|""|no|Proxy URL to use for the connection.||
 |`proxy_password`|""|no|Proxy URL to use for the connection.||
+|`ah_token`|""|yes|Tower Admin User's token on the Automation Hub Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
 |`download_concurrency`|"10"|no| Number of concurrent collections to download.||
 |`rate_limit`|"8"|no|Limits total download rate in requests per second||
 |`signed_only`|"False"|no|Only download signed collections|True|

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -24,6 +24,7 @@
     ah_host:              "{{ ah_host | default(ah_hostname) }}"
     ah_username:          "{{ ah_username | default(omit) }}"
     ah_password:          "{{ ah_password | default(omit) }}"
+    ah_token:             "{{ ah_token | default(omit) }}"
     ah_path_prefix:       "{{ ah_path_prefix | default(omit) }}"
     validate_certs:       "{{ ah_validate_certs | default(omit) }}"
   no_log: "{{ ah_configuration_repository_secure_logging }}"

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -16,6 +16,7 @@
     ah_host:          "{{ ah_host | default(ah_hostname) }}"
     ah_username:      "{{ ah_username | default(omit) }}"
     ah_password:      "{{ ah_password | default(omit) }}"
+    ah_token:         "{{ ah_token | default(omit) }}"
     ah_path_prefix:   "{{ ah_path_prefix | default(omit) }}"
     validate_certs:   "{{ ah_validate_certs | default(omit) }}"
   loop: "{{ ah_users }}"


### PR DESCRIPTION
### What does this PR do?
adds the missing `ah_token` in all the roles that in the README.md but not in the role itself.

### How should this be tested?
n/a

### Is there a relevant Issue open for this?
n/a

### Other Relevant info, PRs, etc.
Related to `PR #147`.   Found more missing `ah_token` in the other roles that needed to be added so a new token is not generated when called.  
