### PR TITLE
Align linting configurations with other repos

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,7 +14,8 @@ use_default_rules: true
 # with verbosity set to 1, its dumping 'unknown file type messages'
 # verbosity: 1
 skip_list: []
-# With the move of the .yamllint.yml to TLD ansible-lint now picks up our config so no need to exclude it.
-# YAML: Ansible lint doing yaml checks that we were already doing but without config.
-# - yaml
+kinds:
+  - playbooks: "**/examples/*.{yml,yaml}"
+  - tasks: "**/examples/tasks/*.yml"
+  - vars: "**/examples/vars/*.yml"
 ...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,6 +1,6 @@
 ---
 # This workflow action will run pre-commit, which will execute ansible and yaml linting
-# See .github/workflow-config/.pre-commit-config.yml for what hooks are executed
+# See .pre-commit-config.yml for what hooks are executed
 name: Yaml and Ansible Lint
 
 on: [push, pull_request]  # yamllint disable-line rule:truthy

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -13,13 +13,12 @@ rules:
   document-end: {present: true}
   indentation:
     level: error
-    indent-sequences: consistent
+    # Require indentation https://redhat-cop.github.io/automation-good-practices/#_yaml_and_jinja2_syntax
+    indent-sequences: true
   truthy:
     level: error
+    # Allow only YAML 1.2 booleans https://redhat-cop.github.io/automation-good-practices/#_yaml_and_jinja2_syntax
     allowed-values:
-    - 'True'
-    - 'False'
-    - 'true'
-    - 'false'
-    - 'on'
+      - 'true'
+      - 'false'
 ...


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

This is a small linting update to align the ah_configuration linting with the other redhat_cop AAP related repos.

### How should this be tested?

Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples)

### Is there a relevant Issue open for this?

No

### Other Relevant info, PRs, etc

None