### PR TITLE
multiple fixes

### DIFF
--- a/plugins/module_utils/ah_module.py
+++ b/plugins/module_utils/ah_module.py
@@ -554,7 +554,7 @@ class AHModule(AnsibleModule):
         i = 0
         while i < 5:
             if not response:
-                time.sleep(1)
+                time.sleep(15)
                 response = self.post_endpoint("{0}/{1}".format(endpoint, approvalEndpoint), None, **{"return_none_on_404": True})
                 i += 1
             else:

--- a/roles/publish/tasks/main.yml
+++ b/roles/publish/tasks/main.yml
@@ -19,7 +19,7 @@
     src:  "{{ __ah_collection_item.collection_local_path }}/"
     dest: "{{ ah_configuration_working_dir }}/{{ __ah_collection_item.collection_name }}"
     remote_src: true
-    mode: 0644
+    mode: 0755
   loop: "{{ ah_collections }}"
   loop_control:
     loop_var: "__ah_collection_item"
@@ -122,7 +122,7 @@
   loop_control:
     loop_var: "__ah_collection_file"
   no_log: "{{ ah_configuration_publish_secure_logging }}"
-  when: ah_auto_approve
+  when: not ah_auto_approve
   register: approval
   retries: 3
   delay: 2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

- 5 seconds waiting for a HTTP answer are not enough for low dimensioned AH instance
- `publish` role was creating the temporary directory with the wrong permissions and treating the `ah_auto_approve` variable by the wrong way
- `ah_token` parameter is not supported by any of the underlying modules (Example for `groups` can be found below): 
![image](https://user-images.githubusercontent.com/26822043/194319576-f61f4d3b-f5d2-4e88-bf88-cbc5dc23b8e0.png)

### How should this be tested?

```yaml
---
- name: Playbook to configure Private Automation Hub
  hosts: localhost
  connection: local
  gather_facts: false
  collections:
    - redhat_cop.ah_configuration

  vars:
    target_state: "present"

  pre_tasks:
    - name: Include Vars
      include_vars: vars/pah_vars.yml
      tags:
        - always

  tasks:
    - name: Include task to manage private automation hub groups
      include_tasks: tasks/manage_groups.yml
      tags:
        - groups

    - name: Include task to manage private automation hub users
      include_tasks: tasks/manage_users.yml
      tags:
        - users

    # # All tasks below here may need to be re-ordered so they
    # # execute in a particular order.
    # - name: Include task for managing collection namespaces
    #   include_tasks: tasks/manage_collection_namespaces.yml
    #   tags:
    #     - namespaces

    # - name: Include task for repository
    #   include_tasks: tasks/manage_repository.yml
    #   tags:
    #     - repos

    # - name: Include task for repository sync
    #   include_tasks: tasks/manage_repository_sync.yml
    #   tags:
    #     - reposync

    - name: Include task for execution environment images
      include_tasks: tasks/manage_ee_images.yml
      tags:
        - ee_images

    - name: Include task to manage execution enviornment namespaces
      include_tasks: tasks/manage_ee_namespaces.yml
      tags:
        - ee_namespaces

    - name: Include task to manage execution environment registries
      include_tasks: tasks/manage_ee_registries.yml
      tags:
        - registries

    - name: Include task to manage execution environment registry indices
      include_tasks: tasks/manage_ee_registry_indices.yml
      tags:
        - indices

    - name: Include task to manage execution environment registry sync
      include_tasks: tasks/manage_ee_registry_sync.yml
      tags:
        - regsync

    - name: Include task to manage execution environment repositories
      include_tasks: tasks/manage_ee_repositories.yml
      tags:
        - repos

    - name: Include task to manage execution environment repository sync
      include_tasks: tasks/manage_ee_repository_sync.yml
      tags:
        - reposync

    - name: Include task to manage collection publish
      include_tasks: tasks/manage_collection_publish.yml
      tags:
        - publish
...
```
```bash
$ ansible-playbook pah_configure.yml -e @vars/pah_vars.yml
```

### Is there a relevant Issue open for this?

No Issue has been opened for this PR.

### Other Relevant info, PRs, etc

N/A