### PR TITLE
Draft: add ah token to auth ui doc fragment

### DIFF
--- a/plugins/doc_fragments/auth_ui.py
+++ b/plugins/doc_fragments/auth_ui.py
@@ -31,6 +31,14 @@ options:
     - Password for your Ansible Galaxy or Automation Hub instance.
     - If value not set, will try environment variable C(AH_PASSWORD)
     type: str
+  ah_token:
+    description:
+    - The Ansible Galaxy or Automation Hub API token to use.
+    - This value can be in one of two formats.
+    - A string which is the token itself. (i.e. bqV5txm97wqJqtkxlMkhQz0pKhRMMX)
+    - A dictionary structure as returned by the ah_token module.
+    - If value not set, will try environment variable C(AH_API_TOKEN)
+    type: raw
   validate_certs:
     description:
     - Whether to allow insecure connections to Galaxy or Automation Hub Server.

--- a/plugins/module_utils/ah_api_module.py
+++ b/plugins/module_utils/ah_api_module.py
@@ -50,6 +50,7 @@ class AHAPIModule(AnsibleModule):
         ah_password=dict(no_log=True, required=False, fallback=(env_fallback, ["AH_PASSWORD"])),
         ah_path_prefix=dict(required=False, fallback=(env_fallback, ["GALAXY_API_PATH_PREFIX"])),
         validate_certs=dict(type="bool", aliases=["ah_verify_ssl"], required=False, fallback=(env_fallback, ["AH_VERIFY_SSL"])),
+        ah_token=dict(type="raw", no_log=True, required=False, fallback=(env_fallback, ["AH_API_TOKEN"])),
     )
     short_params = {
         "host": "ah_host",
@@ -57,11 +58,13 @@ class AHAPIModule(AnsibleModule):
         "password": "ah_password",
         "verify_ssl": "validate_certs",
         "path_prefix": "ah_path_prefix",
+        "oauth_token": "ah_token",
     }
 
     host = "127.0.0.1"
     username = None
     password = None
+    oauth_token = None
     verify_ssl = True
     path_prefix = "galaxy"
     authenticated = False


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

This should add the ah_token to multiple modules that are currently missing it. 

modules include this file like so
https://github.com/redhat-cop/ah_configuration/blob/devel/plugins/modules/ah_user.py#L79