### PR TITLE
remove unsupported ah_token parameter from group role

### DIFF
--- a/roles/group/tasks/main.yml
+++ b/roles/group/tasks/main.yml
@@ -9,7 +9,7 @@
     ah_host:          "{{ ah_host | default(ah_hostname) }}"
     ah_username:      "{{ ah_username | default(omit) }}"
     ah_password:      "{{ ah_password | default(omit) }}"
-    ah_token:         "{{ ah_token | default(omit) }}"
+    # ah_token:         "{{ ah_token | default(omit) }}"
     ah_path_prefix:   "{{ ah_path_prefix | default(omit) }}"
     validate_certs:   "{{ ah_validate_certs | default(omit) }}"
   loop: "{{ ah_groups }}"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
### What does this PR do?

remove unsupported ah_token parameter from group role

### Is there a relevant Issue open for this?

resolves #163

### Other Relevant info, PRs, etc

#162 
