### PR TITLE
Fix issue where user thought they could add token to ah_api lookup plugin

### DIFF
--- a/plugins/doc_fragments/auth_plugin.py
+++ b/plugins/doc_fragments/auth_plugin.py
@@ -25,11 +25,6 @@ options:
     description: The password for your controller user.
     env:
     - name: AH_PASSWORD
-  oauth_token:
-    description:
-    - The OAuth token to use.
-    env:
-    - name: AH_OAUTH_TOKEN
   path_prefix:
     description:
     - API path used to access the api.

--- a/plugins/lookup/ah_api.py
+++ b/plugins/lookup/ah_api.py
@@ -175,6 +175,8 @@ class LookupModule(LookupBase):
 
         url = module._build_url("", endpoint=endpoint, query_params=self.get_option("query_params", {}))
 
+        if not (module.username and module.password):
+            raise AnsibleError("Username and Password must be provided to this plugin")
         module.authenticate()
         response = module.make_request("GET", url)
 


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Remove unused oauth2 option from documentation and ensure username and password are provided to ah_api lookup

The doc previously said you could apply a token to the plugin but you cant. I've removed this and added a check if username and password are set and errors out with a better error message if not.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
```
    - ansible.builtin.debug:
        msg: "Collections: {{ lookup('infra.ah_configuration.ah_api', 'namespaces', host=ah_hostname, username=ah_username, password=ah_password, validate_certs=false, return_all=true) }}"
```
will work, but 
```
    - ansible.builtin.debug:
        msg: "Collections: {{ lookup('infra.ah_configuration.ah_api', 'namespaces', host=ah_hostname, validate_certs=false, return_all=true) }}"
```
will not work.
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #196 

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
N/A