### PR TITLE
Update collections api lookup to work across all repos

### DIFF
--- a/changelogs/fragments/api_lookup.yml
+++ b/changelogs/fragments/api_lookup.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - Added option to pull all collections from a specific repository
+bugfixes:
+  - Checks for username and password passed to api lookup plugin
+  - Removed incorrect reference to oauth token abilities for api lookup plugin.
+...

--- a/plugins/lookup/ah_api.py
+++ b/plugins/lookup/ah_api.py
@@ -21,8 +21,8 @@ options:
       - "'ee_namespaces'"
       - "'ee_registries'"
       - "'ee_repositories'"
-      - "'collections'"
-      - "'collection', [repository={published, rh_certified, community}], [collection_namespace], [collection_name]"
+      - "'collections', [repository={published, rh_certified, validated, community}]"
+      - "'collection', [repository={published, rh_certified, validated, community}], [collection_namespace], [collection_name]"
       - "'groups'"
       - "'namespaces'"
       - "'repository_community'"
@@ -145,7 +145,7 @@ class LookupModule(LookupBase):
             "ee_namespaces": "/pulp/api/v3/pulp_container/namespaces/",
             "ee_registries": "/api/{prefix}/_ui/v1/registry/",
             "ee_repositories": "/api/{prefix}/_ui/v1/execution-environments/repositories/",
-            "collections": "/api/{prefix}/v3/collections/",
+            "collections": "/api/{prefix}/v3/plugin/ansible/content/{repository}/collections/index/",
             "collection": "/api/{prefix}/_ui/v1/repo/{repository}/{namespace}/{name}",
             "groups": "/api/{prefix}/_ui/v1/groups/",
             "namespaces": "/api/{prefix}/v3/namespaces/",
@@ -161,6 +161,13 @@ class LookupModule(LookupBase):
             if len(terms) != 2:
                 raise AnsibleError("A second term for the name of the ee repository is required")
             endpoint = endpoints[terms[0]].format(prefix=module.path_prefix, ee_repository=terms[1])
+        elif terms[0] == "collections":
+            if len(terms) != 2:
+                raise AnsibleError("2 terms are required with: 'collection', <repository>")
+            endpoint = endpoints[terms[0]].format(
+                prefix=module.path_prefix,
+                repository=terms[1]
+            )
         elif terms[0] == "collection":
             if len(terms) != 4:
                 raise AnsibleError("4 terms are required with: 'collection', <repository>, <namespace>, <name>")

--- a/plugins/lookup/ah_api.py
+++ b/plugins/lookup/ah_api.py
@@ -21,7 +21,7 @@ options:
       - "'ee_namespaces'"
       - "'ee_registries'"
       - "'ee_repositories'"
-      - "'collections', [repository={published, rh_certified, validated, community}]"
+      - "'collections', [repository={published, rh_certified, validated, community}, default=published]"
       - "'collection', [repository={published, rh_certified, validated, community}], [collection_namespace], [collection_name]"
       - "'groups'"
       - "'namespaces'"
@@ -162,8 +162,10 @@ class LookupModule(LookupBase):
                 raise AnsibleError("A second term for the name of the ee repository is required")
             endpoint = endpoints[terms[0]].format(prefix=module.path_prefix, ee_repository=terms[1])
         elif terms[0] == "collections":
-            if len(terms) != 2:
+            if len(terms) > 2:
                 raise AnsibleError("2 terms are required with: 'collection', <repository>")
+            elif len(terms) == 1:
+                terms += ['published']
             endpoint = endpoints[terms[0]].format(
                 prefix=module.path_prefix,
                 repository=terms[1]


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Updates the lookup plugin for the API to work with the collections query to pull from a specific repository. It seems the URL has changed (although redirected) which meant that only the published collections were being pulled. There doesn't seem to be a way to get all the collections now so sensible thing to do is to take the repository we want to query and pull from that.

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
```
- ansible.builtin.debug:
        msg: "Collections: {{ lookup('infra.ah_configuration.ah_api', 'collections', 'community', host=ah_hostname, username=ah_username, password=ah_password, validate_certs=false, return_all=true) }}"
```

also if the repository is not provided it shall still work and default to 'published'
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #198 

# Other Relevant info, PRs, etc
related #196 
related #197 
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
