### PR TITLE
Add sync and index option on respective roles

### DIFF
--- a/changelogs/fragments/sync-index.yml
+++ b/changelogs/fragments/sync-index.yml
@@ -1,0 +1,5 @@
+---
+breaking_changes:
+  - Introduces a `sync` option to the ee_registry_sync role on the `ah_ee_registries` variable which by default is false and which is required true to sync the registry.
+  - Introduces an `index` option to the ee_registry_index role on the `ah_ee_registries` variable which by default is false and which is required true to index the registry.
+...

--- a/roles/ee_registry_index/README.md
+++ b/roles/ee_registry_index/README.md
@@ -13,7 +13,7 @@ An Ansible Role to index EE Registries in Automation Hub.
 |`ah_password`|""|yes|Automation Hub Admin User's password on the Automation Hub Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
-|`ah_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below. (Note this is the same as for the `ee_registries` role and the variable can be combined)||
+|`ah_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below. (Note this is the same as for the `ee_registries` role and the variable can be combined). Note that this role will only do anything if the `index` suboption of this variable is set to true.||
 
 ### Secure Logging Variables
 
@@ -48,6 +48,7 @@ This also speeds up the overall role.
 |Variable Name|Default Value|Required|Type|Description|
 |:---:|:---:|:---:|:---:|:---:|
 |`name`|""|yes|str|Registry name. Must be lower case containing only alphanumeric characters and underscores.|
+|`index`|false|no|bool|Whether to index the ee_registry. Bu default it will not index unless this is set to true.|
 |`wait`|true|no|str|Whether to wait for the indexing to complete|
 |`interval`|`ah_configuration_ee_registry_index_async_delay`|no|str|The interval which the indexing task will be checked for completion|
 |`timeout`|""|no|str|How long to wait for the indexing task to complete|

--- a/roles/ee_registry_index/tasks/main.yml
+++ b/roles/ee_registry_index/tasks/main.yml
@@ -15,6 +15,7 @@
   loop: "{{ ah_ee_registries }}"
   loop_control:
     loop_var: "__ee_registry_item"
+  when: __ee_registry_item.index | default(false)
   no_log: "{{ ah_configuration_ee_registry_secure_logging }}"
   async: 1000
   poll: 0

--- a/roles/ee_registry_sync/README.md
+++ b/roles/ee_registry_sync/README.md
@@ -13,7 +13,7 @@ An Ansible Role to sync EE Registries in Automation Hub.
 |`ah_password`|""|yes|Automation Hub Admin User's password on the Automation Hub Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
-|`ah_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below. (Note this is the same as for the `ee_registries` role and the variable can be combined||
+|`ah_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below. (Note this is the same as for the `ee_registries` role and the variable can be combined. Note that this role will only do anything if the `sync` suboption of this variable is set to true.||
 
 ### Secure Logging Variables
 
@@ -48,6 +48,7 @@ This also speeds up the overall role.
 |Variable Name|Default Value|Required|Type|Description|
 |:---:|:---:|:---:|:---:|:---:|
 |`name`|""|yes|str|Registry name. Must be lower case containing only alphanumeric characters and underscores.|
+|`sync`|false|no|bool|Whether to sync the ee_registry. By default it will not sync unless this is set to true.|
 |`wait`|true|no|str|Whether to wait for the sync to complete|
 |`interval`|`ah_configuration_ee_registry_sync_async_delay`|no|str|The interval which the sync task will be checked for completion|
 |`timeout`|""|no|str|How long to wait for the sync task to complete|

--- a/roles/ee_registry_sync/tasks/main.yml
+++ b/roles/ee_registry_sync/tasks/main.yml
@@ -15,6 +15,7 @@
   loop: "{{ ah_ee_registries }}"
   loop_control:
     loop_var: "__ee_registry_item"
+  when: __ee_registry_item.sync | default(false)
   no_log: "{{ ah_configuration_ee_registry_secure_logging }}"
   async: 1000
   poll: 0


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Adds sync or index option on roles to conditionally sync or index. This is based around the fact that you can't index all remote repositories so if you call the index role it will cause issues if one of your repositories isn't registry.redhat.io.

I figure it makes sense to do the same thing with the sync role too since the user may not want to sync either.

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Not sure how great it would be to add to CI for _index and _sync for EEs but it can be tested by calling the role with or without sync and index set as true as options of `ah_ee_registries`
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #167 

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
