### PR TITLE
Simplify dispatch

### DIFF
--- a/roles/collection/README.md
+++ b/roles/collection/README.md
@@ -40,15 +40,13 @@ ah_configuration_repository_secure_logging defaults to the value of ah_configura
 
 ```yaml
 ---
-collection:
-  namespace: 'awx'
-  name: 'awx'
-  path: /var/tmp/collections/awx_awx-15.0.0.tar.gz
-  state: present
+ah_collections:
+  - namespace: 'awx'
+    name: 'awx'
+    path: /var/tmp/collections/awx_awx-15.0.0.tar.gz
+    state: present
 
-- name: Remove collection
-  ah_collection:
-    namespace: test_collection
+  - namespace: test_collection
     name: test
     version: 4.1.2
     state: absent

--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -1,14 +1,13 @@
 ---
 ah_configuration_dispatcher_roles:
-  - {role: group, var: [ah_groups], tags: groups}
-  - {role: user, var: [ah_users], tags: users}
-  - {role: ansible_config, var: [ansible_config_list, automation_hub_list], tags: config}
-  - {role: namespace, var: [ah_ee_namespaces], tags: namespaces}
-  - {role: collection, var: [ah_collections], tags: collections}
-  - {role: ee_repository, var: [ah_ee_repositories], tags: repos}
-  - {role: ee_repository_sync, var: [ah_ee_repository_sync], tags: reposync}
-  - {role: ee_image, var: [ah_ee_images], tags: images}
-  - {role: ee_registry, var: [ah_ee_registries], tags: registries}
-  - {role: ee_registry_index, var: [ah_ee_registries], tags: indices}
-  - {role: ee_registry_sync, var: [ah_ee_registries], tags: regsync}
+  - {role: group, var: ah_groups, tags: groups}
+  - {role: user, var: ah_users, tags: users}
+  - {role: namespace, var: ah_ee_namespaces, tags: namespaces}
+  - {role: collection, var: ah_collections, tags: collections}
+  - {role: ee_repository, var: ah_ee_repositories, tags: repos}
+  - {role: ee_repository_sync, var: ah_ee_repository_sync, tags: reposync}
+  - {role: ee_image, var: ah_ee_images, tags: images}
+  - {role: ee_registry, var: ah_ee_registries, tags: registries}
+  - {role: ee_registry_index, var: ah_ee_registries, tags: indices}
+  - {role: ee_registry_sync, var: ah_ee_registries, tags: regsync}
 ...

--- a/roles/dispatch/tasks/main.yml
+++ b/roles/dispatch/tasks/main.yml
@@ -5,7 +5,7 @@
     name: "{{ __role.role }}"
     apply:
       tags: "{{ __role.tags }}"
-  when: hostvars[inventory_hostname][__role.var] | length > 0
+  when: hostvars[inventory_hostname][__role.var] is defined
   tags: always
   loop: "{{ ah_configuration_dispatcher_roles }}"
   loop_control:

--- a/roles/publish/README.md
+++ b/roles/publish/README.md
@@ -75,7 +75,7 @@ ah_auto_approve: true
 
 ```yaml
 ---
-- name: Add namespace to Automation Hub
+- name: Build and add collection to Automation Hub
   hosts: localhost
   connection: local
   gather_facts: false
@@ -92,7 +92,7 @@ ah_auto_approve: true
       tags:
         - always
   roles:
-    - ../../publish
+    - infra.ah_configuration.publish
 ```
 
 ## License


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Simplifies dispatch role which didn't really work before
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?

```
- name: Playbook to configure Ansible Automation Hub post installation
  hosts: ah
  vars:
    ah_hostname: ah.aap23.local
    ah_username: admin
    ah_password: password
    ah_validate_certs: false
    ah_groups:
      - name: group1
    ah_users:
      - username: user1
        groups:
          - group1
        password: P455w0rd!
    ah_namespaces:
      - name: my_ns
        description: a new NS
      - name: ns2
        description: Another NS
    ah_collections:
      - namespace: 'infra'
        name: 'ah_configuration'
        path: infra-ah_configuration-0.10.0.tar.gz
        state: present
  roles:
    - infra.ah_configuration.dispatch
```

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
