### PR TITLE
Skip ansible-lint rules

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -20,7 +20,6 @@ skip_list:
   - role-name[path]
 warn_list:
   - jinja[invalid]  # Temporarily adding this due to https://github.com/ansible/ansible-lint/issues/3048
-  - jinja[spacing]  # Would be set to warn by default and the only flagged issues are fairly unfixable
 kinds:
   - playbooks: "**/examples/*.{yml,yaml}"
   - tasks: "**/examples/tasks/*.yml"

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -14,8 +14,13 @@ use_default_rules: true
 # with verbosity set to 1, its dumping 'unknown file type messages'
 # verbosity: 1
 skip_list:
-  - meta-runtime
+  - meta-unsupported-ansible
+  - meta-runtime  # This collection with the appropriate awx.awx or ansible.controller still works with older ansible.
   - fqcn[keyword]
+  - role-name[path]
+warn_list:
+  - jinja[invalid]  # Temporarily adding this due to https://github.com/ansible/ansible-lint/issues/3048
+  - jinja[spacing]  # Would be set to warn by default and the only flagged issues are fairly unfixable
 kinds:
   - playbooks: "**/examples/*.{yml,yaml}"
   - tasks: "**/examples/tasks/*.yml"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes lint issues caused by update to ansible-lint 6.13.0
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
CI should pass
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
N/A

# Other Relevant info, PRs, etc
Note that I've set jinja[invalid] to warn for now because the new version has caused a regression in this rule which I've raised a bug for and linked to from the PR in controller_configuration https://github.com/redhat-cop/controller_configuration/pull/503
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
