### PR TITLE
add missing ah_token option for community repository

### DIFF
--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -54,6 +54,7 @@
     ah_host:              "{{ ah_host | default(ah_hostname) }}"
     ah_username:          "{{ ah_username | default(omit) }}"
     ah_password:          "{{ ah_password | default(omit) }}"
+    ah_token:             "{{ ah_token | default(omit) }}"
     ah_path_prefix:       "{{ ah_path_prefix | default(omit) }}"
     validate_certs:       "{{ ah_validate_certs | default(omit) }}"
   no_log: "{{ ah_configuration_repository_secure_logging }}"


### PR DESCRIPTION


<!--- markdownlint-disable MD041 -->
# What does this PR do?
Commit 5e5f76d did add ah_token for the certified repository, but not for community repository. This commit adds that.

# How should this be tested?

Use the simple example from https://github.com/redhat-cop/ah_configuration/blob/devel/roles/repository/README.md with ah_token as authentication method.

# Is there a relevant Issue open for this?

Didn't find one.

# Other Relevant info, PRs, etc

-
