### PR TITLE
Fixed minor README mistakes and broken table

### DIFF
--- a/roles/ee_registry/README.md
+++ b/roles/ee_registry/README.md
@@ -68,7 +68,7 @@ This also speeds up the overall role.
 ---
 ah_ee_registries:
   - name: myreg
-    url: url: https://quay.io/my/registry
+    url: https://quay.io/my/registry
 ```
 
 ## Playbook Examples

--- a/roles/ee_registry_index/README.md
+++ b/roles/ee_registry_index/README.md
@@ -61,7 +61,7 @@ This also speeds up the overall role.
 ---
 ah_ee_registries:
   - name: myreg
-    url: url: https://quay.io/my/registry
+    url: https://quay.io/my/registry
     interval: 10
     wait: true
     timeout: 300

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -48,7 +48,6 @@ This also speeds up the overall role.
 |Variable Name|Default Value|Required|Type|Description|
 |:---:|:---:|:---:|:---:|:---:|
 |`username`|""|yes|str|Username. Must be lower case containing only alphanumeric characters and underscores.|
-<!-- |`new_name`|""|yes|str|Setting this option will change the existing name (looked up via the name field.| -->
 |`groups`|[]|no|list|List of the groups to update.|
 |`append`|true|no|str|Whether to append or replace the group list provided.|
 |`first_name`|""|no|str|User's first name.|
@@ -57,6 +56,7 @@ This also speeds up the overall role.
 |`is_superuser`|false|no|bool|Whether the user is a superuser.|
 |`password`|""|no|bool|User's password as a clear string. The password must contain at least 9 characters with numbers or special characters.|
 |`state`|`present`|no|str|Desired state of the user.|
+<!-- |`new_name`|""|yes|str|Setting this option will change the existing name (looked up via the name field.| -->
 
 ### Standard Project Data Structure
 


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Fixes some README.md markdown errors in the roles `ee_registry`, `ee_registry_index` and `user`
