### PR TITLE
updates repository and repository sync roles for 2.4 changes

### DIFF
--- a/roles/repository/README.md
+++ b/roles/repository/README.md
@@ -6,10 +6,10 @@ An Ansible Role to create Repositories in Automation Hub.
 
 ## Variables
 
-These are the sub options for the vars `ah_repository_certified` and `ah_repository_community` which are dictionaries with the options you want. See examples for details.
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
-|`url`|`https://cloud.redhat.com/api/automation-hub/`|no|(`ah_repository_certified`)Remote URL for the repository.|`https://console.redhat.com/api/automation-hub/content/1234567-synclist/`|
+|`name`|""|yes| Repository name. Probably one of community, validated, or rh-certified||
+|`url`|`https://cloud.redhat.com/api/automation-hub/`|no|(`ah_repository_certified`)Remote URL for the repository.|`https://console.redhat.com/api/automation-hub/content/`|
 |`url`|`https://galaxy.ansible.com/api/`|no|(`ah_repository_community`)Remote URL for the repository.||
 |`auth_url`|`https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token`|no|(`ah_repository_certified`)Remote URL for the repository authentication if separate.||
 |`token`|""|no|Token to authenticate to the remote repository.||

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -1,62 +1,58 @@
 ---
 # Create AH repository
-- name: Update Certified repository
+- name: Add Automation Hub repository
   ah_repository:
-    name:                 "rh-certified"
-    url:                  "{{ ah_repository_certified['url'] | default('https://cloud.redhat.com/api/automation-hub/') }}"
-    auth_url:             "{{ ah_repository_certified['auth_url'] | default('https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token') }}"
-    token:                "{{ ah_repository_certified['token'] | default(omit) }}"
-    username:             "{{ ah_repository_certified['username'] | default(omit) }}"
-    password:             "{{ ah_repository_certified['password'] | default(omit) }}"
-    download_concurrency: "{{ ah_repository_certified['download_concurrency'] | default(10) }}"
-    rate_limit:           "{{ ah_repository_certified['rate_limit'] | default(8) }}"
-    signed_only:          "{{ ah_repository_certified['signed_only'] | default(false) }}"
-    tls_validation:       "{{ ah_repository_certified['tls_validation'] | default(true) }}"
-    client_key:           "{{ ah_repository_certified['client_key'] | default(omit) }}"
-    client_cert:          "{{ ah_repository_certified['client_cert'] | default(omit) }}"
-    ca_cert:              "{{ ah_repository_certified['ca_cert'] | default(omit) }}"
-    client_key_path:      "{{ ah_repository_certified['client_key_path'] | default(omit) }}"
-    client_cert_path:     "{{ ah_repository_certified['client_cert_path'] | default(omit) }}"
-    ca_cert_path:         "{{ ah_repository_certified['ca_cert_path'] | default(omit) }}"
-    proxy_url:            "{{ proxy_url | default(omit) }}"
-    proxy_username:       "{{ proxy_username | default(omit) }}"
-    proxy_password:       "{{ proxy_password | default(omit) }}"
-    ah_host:              "{{ ah_host | default(ah_hostname) }}"
-    ah_username:          "{{ ah_username | default(omit) }}"
-    ah_password:          "{{ ah_password | default(omit) }}"
-    ah_token:             "{{ ah_token | default(omit) }}"
-    ah_path_prefix:       "{{ ah_path_prefix | default(omit) }}"
-    validate_certs:       "{{ ah_validate_certs | default(omit) }}"
+    name: "{{ __repository_item['name'] }}"
+    url: "{{ __repository_item['url']  }}"
+    auth_url: "{{ __repository_item['auth_url'] | default(omit) }}"
+    token: "{{ __repository_item['token'] | default(omit) }}"
+    username: "{{ __repository_item['username'] | default(omit) }}"
+    password: "{{ __repository_item['password'] | default(omit) }}"
+    requirements: "{{ __repository_item['requirements'] | default(omit) }}"
+    requirements_file: "{{ __repository_item['requirements_file'] | default(omit }}"
+    download_concurrency: "{{ __repository_item['download_concurrency'] | default(10) }}"
+    rate_limit: "{{ __repository_item['rate_limit'] | default(8) }}"
+    signed_only: "{{ __repository_item['signed_only'] | default(omit) }}"
+    tls_validation: "{{ __repository_item['tls_validation'] | default(true) }}"
+    client_key: "{{ __repository_item['client_key'] | default(omit) }}"
+    client_cert: "{{ __repository_item['client_cert'] | default(omit) }}"
+    ca_cert: "{{ __repository_item['ca_cert'] | default(omit) }}"
+    client_key_path: "{{ __repository_item['client_key_path'] | default(omit) }}"
+    client_cert_path: "{{ __repository_item['client_cert_path'] | default(omit) }}"
+    ca_cert_path: "{{ __repository_item['ca_cert_path'] | default(omit) }}"
+    proxy_url: "{{ proxy_url | default(omit) }}"
+    proxy_username: "{{ proxy_username | default(omit) }}"
+    proxy_password: "{{ proxy_password | default(omit) }}"
+    ah_host: "{{ ah_host | default(ah_hostname) }}"
+    ah_username: "{{ ah_username | default(omit) }}"
+    ah_password: "{{ ah_password | default(omit) }}"
+    ah_token: "{{ ah_token | default(omit) }}"
+    ah_path_prefix: "{{ ah_path_prefix | default(omit) }}"
+    validate_certs: "{{ ah_validate_certs | default(omit) }}"
+  loop: "{{ ah_repositories }}"
+  loop_control:
+    loop_var: "__repository_item"
   no_log: "{{ ah_configuration_repository_secure_logging }}"
-  when: ah_repository_certified is defined
+  async: 1000
+  poll: 0
+  register: __repositories_job_async
+  changed_when: not __repositories_job_async.changed
+  vars:
+    ansible_async_dir: '/tmp/.ansible_async'
 
-- name: Update Community repository
-  ah_repository:
-    name:                 "community"
-    url:                  "{{ ah_repository_community['url'] | default('https://galaxy.ansible.com/api/') }}"
-    username:             "{{ ah_repository_community['username'] | default(omit) }}"
-    password:             "{{ ah_repository_community['password'] | default(omit) }}"
-    requirements:         "{{ ah_repository_community['requirements'] | default(omit) }}"
-    requirements_file:    "{{ ah_repository_community['requirements_file'] | default(omit) }}"
-    download_concurrency: "{{ ah_repository_community['download_concurrency'] | default(10) }}"
-    rate_limit:           "{{ ah_repository_community['rate_limit'] | default(8) }}"
-    signed_only:          "{{ ah_repository_community['signed_only'] | default(omit) }}"
-    tls_validation:       "{{ ah_repository_community['tls_validation'] | default(true) }}"
-    client_key:           "{{ ah_repository_community['client_key'] | default(omit) }}"
-    client_cert:          "{{ ah_repository_community['client_cert'] | default(omit) }}"
-    ca_cert:              "{{ ah_repository_community['ca_cert'] | default(omit) }}"
-    client_key_path:      "{{ ah_repository_community['client_key_path'] | default(omit) }}"
-    client_cert_path:     "{{ ah_repository_community['client_cert_path'] | default(omit) }}"
-    ca_cert_path:         "{{ ah_repository_community['ca_cert_path'] | default(omit) }}"
-    proxy_url:            "{{ proxy_url | default(omit) }}"
-    proxy_username:       "{{ proxy_username | default(omit) }}"
-    proxy_password:       "{{ proxy_password | default(omit) }}"
-    ah_host:              "{{ ah_host | default(ah_hostname) }}"
-    ah_username:          "{{ ah_username | default(omit) }}"
-    ah_password:          "{{ ah_password | default(omit) }}"
-    ah_token:             "{{ ah_token | default(omit) }}"
-    ah_path_prefix:       "{{ ah_path_prefix | default(omit) }}"
-    validate_certs:       "{{ ah_validate_certs | default(omit) }}"
+- name: "Create Repository | Wait for finish the repository creation"
+  ansible.builtin.async_status:
+    jid: "{{ __repositories_job_async_result_item.ansible_job_id }}"
+  register: __repositories_job_async_result
+  until: __repositories_job_async_result.finished
+  retries: "{{ ah_configuration_repository_async_retries }}"
+  delay: "{{ ah_configuration_repository_async_delay }}"
+  loop: "{{ __repositories_job_async.results }}"
+  loop_control:
+    loop_var: __repositories_job_async_result_item
+  when: __repositories_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_repository_secure_logging }}"
-  when: ah_repository_community is defined
+  vars:
+    ansible_async_dir: '/tmp/.ansible_async'
+
 ...

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: Add Automation Hub repository
   ah_repository:
     name: "{{ __repository_item['name'] }}"
-    url: "{{ __repository_item['url']  }}"
+    url: "{{ __repository_item['url'] }}"
     auth_url: "{{ __repository_item['auth_url'] | default(omit) }}"
     token: "{{ __repository_item['token'] | default(omit) }}"
     username: "{{ __repository_item['username'] | default(omit) }}"

--- a/roles/repository_sync/README.md
+++ b/roles/repository_sync/README.md
@@ -6,9 +6,9 @@ An Ansible Role to sync Repositories in Automation Hub.
 
 ## Variables
 
-These are the sub options for the vars `ah_repository_certified` and `ah_repository_community` which are dictionaries with the options you want. See examples for details.
 |Variable Name|Default Value|Required|Description|Example|
 |:---:|:---:|:---:|:---:|:---:|
+|`name`|""|yes| Repository name. Probably one of community, validated, or rh-certified.||
 |`wait`|"false"|no|Wait for the repository to finish syncing before returning.||
 |`interval`|"1"|no|The interval to request an update from Automation Hub.||
 |`timeout`|""|no|If waiting for the project to update this will abort after this amount of seconds.||

--- a/roles/repository_sync/tasks/main.yml
+++ b/roles/repository_sync/tasks/main.yml
@@ -1,31 +1,39 @@
 ---
-- name: Sync Automation Hub certified repository
+- name: Sync Automation Hub repository
   ah_repository_sync:
-    name:           "rh-certified"
-    wait:           "{{ ah_repository_certified.wait | default(false) }}"
-    interval:       "{{ ah_repository_certified.interval | default(1) }}"
-    timeout:        "{{ ah_repository_certified.timeout | default(omit) }}"
-    ah_host:        "{{ ah_host | default(ah_hostname) }}"
-    ah_username:    "{{ ah_username | default(omit) }}"
-    ah_password:    "{{ ah_password | default(omit) }}"
-    ah_token:       "{{ ah_token | default(omit) }}"
+    name: "{{ __repository_item.name }}"
+    wait: "{{ __repository_item.wait | default(omit)  }}"
+    interval: "{{ __repository_item.interval | default(1) }}"
+    timeout: "{{ __repository_item.timeout | default(omit) }}"
+    ah_host: "{{ ah_host | default(ah_hostname) }}"
+    ah_username: "{{ ah_username | default(omit) }}"
+    ah_password: "{{ ah_password | default(omit) }}"
+    ah_token: "{{ ah_token | default(omit) }}"
     ah_path_prefix: "{{ ah_path_prefix | default(omit) }}"
-    ah_verify_ssl:  "{{ ah_validate_certs | default(omit) }}"
-  when: ah_repository_certified is defined
+    ah_verify_ssl: "{{ ah_validate_certs | default(omit) }}"
+  loop: "{{ ah_repositories }}"
+  loop_control:
+    loop_var: "__repository_item"
   no_log: "{{ ah_configuration_repository_secure_logging }}"
+  async: 1000
+  poll: 0
+  register: __repositories_syncs_job_async
+  changed_when: not __repositories_syncs_job_async.changed
+  vars:
+    ansible_async_dir: '/tmp/.ansible_async'
 
-- name: Sync Automation Hub community repository
-  ah_repository_sync:
-    name:           "community"
-    wait:           "{{ ah_repository_community.wait | default(false) }}"
-    interval:       "{{ ah_repository_community.interval | default(1) }}"
-    timeout:        "{{ ah_repository_community.timeout | default(omit) }}"
-    ah_host:        "{{ ah_host | default(ah_hostname) }}"
-    ah_username:    "{{ ah_username | default(omit) }}"
-    ah_password:    "{{ ah_password | default(omit) }}"
-    ah_token:       "{{ ah_token | default(omit) }}"
-    ah_path_prefix: "{{ ah_path_prefix | default(omit) }}"
-    ah_verify_ssl:  "{{ ah_validate_certs | default(omit) }}"
-  when: ah_repository_community is defined
+- name: "Repository Sync | Wait for finish the repository_sync to finish"
+  async_status:
+    jid: "{{ __repositories_syncs_job_async_result_item.ansible_job_id }}"
+  register: __repositories_syncs_job_async_result
+  until: __repositories_syncs_job_async_result.finished
+  retries: "{{ ah_configuration_repository_syncs_async_retries }}"
+  delay: "{{ ah_configuration_repository_syncs_async_delay }}"
+  loop: "{{ __repositories_syncs_job_async.results }}"
+  loop_control:
+    loop_var: __repositories_syncs_job_async_result_item
+  when: __repositories_syncs_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_repository_secure_logging }}"
+  vars:
+    ansible_async_dir: '/tmp/.ansible_async'
 ...

--- a/roles/repository_sync/tasks/main.yml
+++ b/roles/repository_sync/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Sync Automation Hub repository
   ah_repository_sync:
     name: "{{ __repository_item.name }}"
-    wait: "{{ __repository_item.wait | default(omit)  }}"
+    wait: "{{ __repository_item.wait | default(omit) }}"
     interval: "{{ __repository_item.interval | default(1) }}"
     timeout: "{{ __repository_item.timeout | default(omit) }}"
     ah_host: "{{ ah_host | default(ah_hostname) }}"
@@ -23,7 +23,7 @@
     ansible_async_dir: '/tmp/.ansible_async'
 
 - name: "Repository Sync | Wait for finish the repository_sync to finish"
-  async_status:
+  ansible.builtin.async_status:
     jid: "{{ __repositories_syncs_job_async_result_item.ansible_job_id }}"
   register: __repositories_syncs_job_async_result
   until: __repositories_syncs_job_async_result.finished

--- a/tests/playbooks/ah_configs/ah_repository.yml
+++ b/tests/playbooks/ah_configs/ah_repository.yml
@@ -1,11 +1,11 @@
 ---
-ah_repository_community:
-  name: community
-  url: https://galaxy.ansible.com/api/
-  requirements:
-    - name: infra.ee_utilities
-    - name: infra.controller_configuration
-  wait: true
-  interval: 25
-  timeout: 1000000
+ah_repositories:
+  - name: community
+    url: https://galaxy.ansible.com/api/
+    requirements:
+      - name: infra.ee_utilities
+      - name: infra.controller_configuration
+    wait: true
+    interval: 25
+    timeout: 1000000
 ...

--- a/tests/playbooks/ah_configs/ah_repository.yml
+++ b/tests/playbooks/ah_configs/ah_repository.yml
@@ -1,5 +1,6 @@
 ---
 ah_repository_community:
+  name: community
   url: https://galaxy.ansible.com/api/
   requirements:
     - name: infra.ee_utilities


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
brings back looping through repositories for adding/updating and syncing them now that in 2.4 it allows for as many remote repositories as users want.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
probably some manual with automated as well
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #267

# Other Relevant info, PRs, etc
none
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
