### PR TITLE
Fix typo in publish role argspec

### DIFF
--- a/roles/publish/meta/argument_specs.yml
+++ b/roles/publish/meta/argument_specs.yml
@@ -1,7 +1,7 @@
 ---
 argument_specs:
   main:
-    short_description: An Ansible Role to create users in Automation Hub.
+    short_description: An Ansible Role to publish collections in Automation Hub.
     options:
       ah_configuration_working_dir:
         default: /var/tmp


### PR DESCRIPTION
short description incorrectly talks about users and not publishing a collection.

<!--- markdownlint-disable MD041 -->
# What does this PR do?
update the role argspec short description to say it's about publishing collections.
<!--- Brief explanation of the code or documentation change you've made -->
fixes what was probably a copy/paste error.
# How should this be tested?

The only consumer of role argspec that I know of is part of docs.ansible.com, where it parses the role argspec to create role documentation from it. 

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
no just a driveby typo fix

