### PR TITLE
add ah_configuration_async_dir var

### DIFF
--- a/roles/collection/README.md
+++ b/roles/collection/README.md
@@ -20,6 +20,10 @@ These are the sub options for the vars `ah_collections` which are dictionaries w
 |`overwrite_existing`|"false"|no|Overwrites an existing collection and requires version to be set.||
 |`state`|"present"|no|Desired state of the resource||
 
+The `ah_configuration_async_dir` variable sets the directory to write the results file for async tasks.
+The default value is `/tmp/.ansible_async`.
+Set to `null` to use Ansible's default value.
+
 ### Secure Logging Variables
 
 The following Variables compliment each other.

--- a/roles/collection/defaults/main.yml
+++ b/roles/collection/defaults/main.yml
@@ -21,4 +21,5 @@ ah_collections: []
 ah_configuration_collection_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_collection_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_collection_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/collection/meta/argument_specs.yml
+++ b/roles/collection/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_collection_secure_logging:

--- a/roles/collection/tasks/main.yml
+++ b/roles/collection/tasks/main.yml
@@ -27,7 +27,7 @@
   register: __collections_job_async
   changed_when: not __collections_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: Sleep for 10 seconds and continue with play
   ansible.builtin.wait_for:
@@ -46,5 +46,5 @@
   when: __collections_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_collection_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/dispatch/README.md
+++ b/roles/dispatch/README.md
@@ -40,6 +40,10 @@ Each item within the variable has three elements:
 
 If the functionality of Automation Hub is extended in the future, and more variables are able to trigger a role, the new variable should be added into the `var` list for the role above.
 
+The `ah_configuration_async_dir` variable sets the directory to write the results file for async tasks.
+The default value is `/tmp/.ansible_async`.
+Set to `null` to use Ansible's default value.
+
 ### Authentication
 
 |Variable Name|Default Value|Required|Description|Example|

--- a/roles/ee_image/README.md
+++ b/roles/ee_image/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create execution environment images in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_images`|`see below`|yes|Data structure describing your execution environment images, described below.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_image/defaults/main.yml
+++ b/roles/ee_image/defaults/main.yml
@@ -22,4 +22,5 @@ ah_ee_images: []
 ah_configuration_ee_image_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_image_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_image_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/ee_image/meta/argument_specs.yml
+++ b/roles/ee_image/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_ee_image_secure_logging:

--- a/roles/ee_image/tasks/main.yml
+++ b/roles/ee_image/tasks/main.yml
@@ -22,7 +22,7 @@
   register: __ee_images_job_async
   changed_when: not __ee_images_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Create EE Image | Wait for finish the ee_image creation"
   ansible.builtin.async_status:
@@ -37,5 +37,5 @@
   when: __ee_images_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_ee_image_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/ee_namespace/README.md
+++ b/roles/ee_namespace/README.md
@@ -15,6 +15,7 @@ This was depreciated with AAP 2.4 and Galaxy NG 4.6.3+, and removed from the API
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_namespaces`|`see below`|yes|Data structure describing your ee_namespaces, described below.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_namespace/defaults/main.yml
+++ b/roles/ee_namespace/defaults/main.yml
@@ -20,4 +20,5 @@ ah_ee_namespaces: []
 ah_configuration_ee_namespace_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_namespace_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_namespace_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/ee_namespace/meta/argument_specs.yml
+++ b/roles/ee_namespace/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_ee_namespace_secure_logging:

--- a/roles/ee_namespace/tasks/main.yml
+++ b/roles/ee_namespace/tasks/main.yml
@@ -22,7 +22,7 @@
   register: __ee_namespaces_job_async
   changed_when: not __ee_namespaces_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Create EE Namespace | Wait for finish the ee_namespace creation"
   ansible.builtin.async_status:
@@ -37,5 +37,5 @@
   when: __ee_namespaces_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_ee_namespace_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/ee_registry/README.md
+++ b/roles/ee_registry/README.md
@@ -17,6 +17,7 @@ An Ansible Role to create EE Registries in Automation Hub.
 |`proxy_username`|""|no|str|The username for the proxy authentication|
 |`proxy_password`|""|no|str|The password for the proxy authentication|
 |`ah_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_registry/defaults/main.yml
+++ b/roles/ee_registry/defaults/main.yml
@@ -26,4 +26,5 @@ ah_ee_registries: []
 ah_configuration_ee_registry_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_registry_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_registry_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/ee_registry/meta/argument_specs.yml
+++ b/roles/ee_registry/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_ee_registry_secure_logging:

--- a/roles/ee_registry/tasks/main.yml
+++ b/roles/ee_registry/tasks/main.yml
@@ -28,7 +28,7 @@
   register: __ee_registries_job_async
   changed_when: not __ee_registries_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Create EE Registry | Wait for finish the ee_registry creation"
   ansible.builtin.async_status:
@@ -43,5 +43,5 @@
   when: __ee_registries_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_ee_registry_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/ee_registry_index/README.md
+++ b/roles/ee_registry_index/README.md
@@ -14,6 +14,7 @@ An Ansible Role to index EE Registries in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below. (Note this is the same as for the `ee_registries` role and the variable can be combined). Note that this role will only do anything if the `index` suboption of this variable is set to true.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_registry_index/defaults/main.yml
+++ b/roles/ee_registry_index/defaults/main.yml
@@ -19,4 +19,5 @@ ah_ee_registries: []
 ah_configuration_ee_registry_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_registry_index_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_registry_index_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/ee_registry_index/meta/argument_specs.yml
+++ b/roles/ee_registry_index/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_ee_registry_secure_logging:

--- a/roles/ee_registry_index/tasks/main.yml
+++ b/roles/ee_registry_index/tasks/main.yml
@@ -22,7 +22,7 @@
   register: __ee_registry_indexes_job_async
   changed_when: not __ee_registry_indexes_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Index EE Registry | Wait for finish the ee_registry_index creation"
   ansible.builtin.async_status:
@@ -37,5 +37,5 @@
   when: __ee_registry_indexes_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_ee_registry_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/ee_registry_sync/README.md
+++ b/roles/ee_registry_sync/README.md
@@ -14,6 +14,7 @@ An Ansible Role to sync EE Registries in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below. (Note this is the same as for the `ee_registries` role and the variable can be combined. Note that this role will only do anything if the `sync` suboption of this variable is set to true.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_registry_sync/defaults/main.yml
+++ b/roles/ee_registry_sync/defaults/main.yml
@@ -19,4 +19,5 @@ ah_ee_registries: []
 ah_configuration_ee_registry_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_registry_sync_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_registry_sync_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/ee_registry_sync/meta/argument_specs.yml
+++ b/roles/ee_registry_sync/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_ee_registry_secure_logging:

--- a/roles/ee_registry_sync/tasks/main.yml
+++ b/roles/ee_registry_sync/tasks/main.yml
@@ -22,7 +22,7 @@
   register: __ee_registry_syncs_job_async
   changed_when: not __ee_registry_syncs_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "EE Registry Sync | Wait for finish the ee_registry_sync to complete"
   ansible.builtin.async_status:
@@ -37,5 +37,5 @@
   when: __ee_registry_syncs_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_ee_registry_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/ee_repository/README.md
+++ b/roles/ee_repository/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create Repositories in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_repositories`|`see below`|yes|Data structure describing your ee_repositories, described below.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_repository/defaults/main.yml
+++ b/roles/ee_repository/defaults/main.yml
@@ -19,4 +19,5 @@ ah_ee_repositories: []
 ah_configuration_ee_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_repository_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_repository_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/ee_repository/meta/argument_specs.yml
+++ b/roles/ee_repository/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_ee_repository_secure_logging:

--- a/roles/ee_repository/tasks/main.yml
+++ b/roles/ee_repository/tasks/main.yml
@@ -26,7 +26,7 @@
   register: __ee_repositories_job_async
   changed_when: not __ee_repositories_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Create EE Repository | Wait for finish the ee_repository creation"
   ansible.builtin.async_status:
@@ -41,5 +41,5 @@
   when: __ee_repositories_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_ee_repository_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/ee_repository_sync/README.md
+++ b/roles/ee_repository_sync/README.md
@@ -14,6 +14,7 @@ An Ansible Role to sync EE Repositories in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_repositories`|`see below`|yes|Data structure describing your ee_repositories, described below. (Note this is the same as for the `ee_repository` role and the variable can be combined. Note that this role will only do anything if the `sync` suboption of this variable is set to true.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_repository_sync/defaults/main.yml
+++ b/roles/ee_repository_sync/defaults/main.yml
@@ -19,4 +19,5 @@ ah_ee_repositories: []
 ah_configuration_ee_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_repository_sync_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_repository_sync_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/ee_repository_sync/meta/argument_specs.yml
+++ b/roles/ee_repository_sync/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_ee_repository_secure_logging:

--- a/roles/ee_repository_sync/tasks/main.yml
+++ b/roles/ee_repository_sync/tasks/main.yml
@@ -22,7 +22,7 @@
   register: __ee_repository_syncs_job_async
   changed_when: not __ee_repository_syncs_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "EE Repository Sync | Wait for finish the ee_repository_sync to finish"
   ansible.builtin.async_status:
@@ -37,5 +37,5 @@
   when: __ee_repository_syncs_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_ee_repository_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/group/README.md
+++ b/roles/group/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create groups in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_groups`|`see below`|yes|Data structure describing your groups, described below.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/group/defaults/main.yml
+++ b/roles/group/defaults/main.yml
@@ -18,4 +18,5 @@ ah_groups: []
 ah_configuration_group_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_group_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_group_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/group/meta/argument_specs.yml
+++ b/roles/group/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_group_secure_logging:

--- a/roles/group/tasks/main.yml
+++ b/roles/group/tasks/main.yml
@@ -21,7 +21,7 @@
   register: __groups_job_async
   changed_when: not __groups_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Create Group | Wait for finish the group creation"
   ansible.builtin.async_status:
@@ -36,7 +36,7 @@
   when: __groups_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_group_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: Add Automation Hub group permissions
   ah_group_perm:
@@ -58,7 +58,7 @@
   register: __group_perms_job_async
   changed_when: not __group_perms_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Create Group | Wait for finish the group creation"
   ansible.builtin.async_status:
@@ -73,5 +73,5 @@
   when: __group_perms_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_group_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/namespace/README.md
+++ b/roles/namespace/README.md
@@ -15,6 +15,7 @@ An Ansible Role to create Namespaces in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_namespaces`|`see below`|yes|Data structure describing your namespaces, described below.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/namespace/defaults/main.yml
+++ b/roles/namespace/defaults/main.yml
@@ -28,4 +28,5 @@ ah_namespaces: []
 ah_configuration_namespace_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_namespace_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_namespace_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/namespace/meta/argument_specs.yml
+++ b/roles/namespace/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_namespace_secure_logging:

--- a/roles/namespace/tasks/main.yml
+++ b/roles/namespace/tasks/main.yml
@@ -28,7 +28,7 @@
   register: __namespaces_job_async
   changed_when: not __namespaces_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Create Namespace | Wait for finish the namespace creation"
   ansible.builtin.async_status:
@@ -43,5 +43,5 @@
   when: __namespaces_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_namespace_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/publish/README.md
+++ b/roles/publish/README.md
@@ -16,6 +16,7 @@ An Ansible Role to publish collections to Automation Hub or Galaxies.
 |`ah_configuration_working_dir`|`/var/tmp`|no|The working directory where the built artifacts live, or where the artifacts will be built.||
 |`ah_auto_approve`|`False`|no|Whether the collection will be automatically approved in Automation Hub. This will only work if the account being used has correct privileges.||
 |`ah_overwrite_existing`|`False`|no|Whether the collection will be automatically overwrite an existing collection in Automation Hub. This will only work if the account being used has correct privileges.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/publish/defaults/main.yml
+++ b/roles/publish/defaults/main.yml
@@ -25,4 +25,5 @@ ah_overwrite_existing: false
 ah_configuration_publish_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_publish_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_publish_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/publish/meta/argument_specs.yml
+++ b/roles/publish/meta/argument_specs.yml
@@ -48,6 +48,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_publish_secure_logging:

--- a/roles/publish/tasks/main.yml
+++ b/roles/publish/tasks/main.yml
@@ -91,7 +91,7 @@
   register: __publish_job_async
   changed_when: not __publish_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Publish Collection | Wait for finish the publish creation"
   ansible.builtin.async_status:
@@ -106,7 +106,7 @@
   when: __publish_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_publish_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: Approve Collections
   ah_approval:

--- a/roles/repository/README.md
+++ b/roles/repository/README.md
@@ -32,6 +32,10 @@ An Ansible Role to create Repositories in Automation Hub.
 |`client_cert_path`|""|no|Path to a PEM encoded client certificate used for authentication||
 |`ca_cert_path`|""|no|Path to a PEM encoded CA certificate used for authentication||
 
+The `ah_configuration_async_dir` variable sets the directory to write the results file for async tasks.
+The default value is `/tmp/.ansible_async`.
+Set to `null` to use Ansible's default value.
+
 ### Secure Logging Variables
 
 The following Variables compliment each other.

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -10,4 +10,5 @@
 ah_configuration_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_repository_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_repository_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/repository/meta/argument_specs.yml
+++ b/roles/repository/meta/argument_specs.yml
@@ -24,6 +24,12 @@ argument_specs:
         type: str
         description: Information regarding the proxy that AH will use to communicate to the Red Hat repositories. Can be left empty if no proxy used.
 
+      # Async variables
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+
       # No_log variables
       ah_configuration_repository_secure_logging:
         default: "{{ ah_configuration_secure_logging | default(false) }}"

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -38,7 +38,7 @@
   register: __repositories_job_async
   changed_when: not __repositories_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Create Repository | Wait for finish the repository creation"
   ansible.builtin.async_status:
@@ -53,6 +53,6 @@
   when: __repositories_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_repository_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 ...

--- a/roles/repository_sync/README.md
+++ b/roles/repository_sync/README.md
@@ -13,6 +13,10 @@ An Ansible Role to sync Repositories in Automation Hub.
 |`interval`|"1"|no|The interval to request an update from Automation Hub.||
 |`timeout`|""|no|If waiting for the project to update this will abort after this amount of seconds.||
 
+The `ah_configuration_async_dir` variable sets the directory to write the results file for async tasks.
+The default value is `/tmp/.ansible_async`.
+Set to `null` to use Ansible's default value.
+
 ### Secure Logging Variables
 
 The following Variables compliment each other.

--- a/roles/repository_sync/defaults/main.yml
+++ b/roles/repository_sync/defaults/main.yml
@@ -10,4 +10,5 @@
 ah_configuration_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_repository_sync_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_repository_sync_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/repository_sync/meta/argument_specs.yml
+++ b/roles/repository_sync/meta/argument_specs.yml
@@ -12,6 +12,12 @@ argument_specs:
         description: Data structure describing the community repository to manage.
         type: dict
 
+      # Async variables
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+
       # No_log variables
       ah_configuration_repository_secure_logging:
         default: "{{ ah_configuration_secure_logging | default(false) }}"

--- a/roles/repository_sync/tasks/main.yml
+++ b/roles/repository_sync/tasks/main.yml
@@ -20,7 +20,7 @@
   register: __repositories_syncs_job_async
   changed_when: not __repositories_syncs_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Repository Sync | Wait for finish the repository_sync to finish"
   ansible.builtin.async_status:
@@ -35,5 +35,5 @@
   when: __repositories_syncs_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_repository_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/role/README.md
+++ b/roles/role/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create role permisions in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_roles`|`see below`|yes|Data structure describing your role permisions, described below.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/role/defaults/main.yml
+++ b/roles/role/defaults/main.yml
@@ -18,4 +18,5 @@ ah_roles: []
 ah_configuration_role_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_role_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_role_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/role/meta/argument_specs.yml
+++ b/roles/role/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_role_secure_logging:

--- a/roles/role/tasks/main.yml
+++ b/roles/role/tasks/main.yml
@@ -21,7 +21,7 @@
   register: __roles_job_async
   changed_when: not __roles_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Create Role | Wait for finish the role creation"
   ansible.builtin.async_status:
@@ -36,5 +36,5 @@
   when: __roles_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_role_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -14,6 +14,7 @@ An Ansible Role to create execution environment images in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_users`|`see below`|yes|Data structure describing your execution environment images, described below.||
+|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
 
 ### Secure Logging Variables
 

--- a/roles/user/defaults/main.yml
+++ b/roles/user/defaults/main.yml
@@ -24,4 +24,5 @@ ah_users: []
 ah_configuration_user_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_user_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_user_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
+ah_configuration_async_dir: /tmp/.ansible_async
 ...

--- a/roles/user/meta/argument_specs.yml
+++ b/roles/user/meta/argument_specs.yml
@@ -27,6 +27,10 @@ argument_specs:
         default: 1
         required: false
         description: This variable sets delay between retries across all roles as a default.
+      ah_configuration_async_dir:
+        default: /tmp/.ansible_async
+        required: false
+        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
 
       # No_log variables
       ah_configuration_user_secure_logging:

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -27,7 +27,7 @@
   register: __users_job_async
   changed_when: not __users_job_async.changed
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 
 - name: "Create User | Wait for finish the user creation"
   ansible.builtin.async_status:
@@ -42,5 +42,5 @@
   when: __users_job_async_result_item.ansible_job_id is defined
   no_log: "{{ ah_configuration_user_secure_logging }}"
   vars:
-    ansible_async_dir: '/tmp/.ansible_async'
+    ansible_async_dir: '{{ ah_configuration_async_dir }}'
 ...


### PR DESCRIPTION
Allows setting ansible_async_dir, to work around issues with the value used by the collection.

<!--- markdownlint-disable MD041 -->
# What does this PR do?

Creates a new variable `ah_configuration_async_dir` on all roles which use the async keyword on tasks, which sets the `ansible_async_dir` variable on those tasks.

I'm trying to use these roles from Ansible Automation Platform, and I get the error "could not find job" from the `ansible.builtin.async_status` tasks.
I'm currently working with Red Hat support to troubleshoot the issue.
In the mean time, I propose updating this collection to allow setting the ansible_async_dir to Ansible's default, or some other directory.
The issue I'm having seems to be related to redhat-cop/controller_configuration issue 299

This change could probably be made much simpler by removing the var from each role. That would break compatibility, but anyone wanting to restore that behaviour could set `ansible_async_dir` in their playbook.

It was also not clear how to handle a variable that was shared by all roles. I've done my best to imitate how some of the other variables were defined.
Something I noticed was the way that variables are described in role READMEs are a bit inconsistent, compare roles/ee_namespace/README.md and roles/repository/README.md.

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?

I haven't updated tests here, but I have successfully tested this change with the `infra.ah_configuration.namespace` role on Ansible Automation Platform.

I guess an automated test could run a role three times, with `ah_configuration_async_dir` unset, set to some path, and set to null.

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->