### PR TITLE
Set Async dir to Ansible Default

### DIFF
--- a/changelogs/fragments/async.yml
+++ b/changelogs/fragments/async.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add option to change async directory, and set the default to null. /tmp/.ansible_async was a workaround while the default was broken previously.
+...

--- a/changelogs/fragments/general_changes.yml
+++ b/changelogs/fragments/general_changes.yml
@@ -1,0 +1,8 @@
+---
+bugfixes:
+  - "add ah_token for the community repository. This commit adds that."
+
+minor_changes:
+  - "remove unused import module"
+  - "Simplify dispatch role"
+...

--- a/changelogs/fragments/general_changes.yml
+++ b/changelogs/fragments/general_changes.yml
@@ -1,8 +1,0 @@
----
-bugfixes:
-  - "add ah_token for the community repository. This commit adds that."
-
-minor_changes:
-  - "remove unused import module"
-  - "Simplify dispatch role"
-...

--- a/roles/collection/README.md
+++ b/roles/collection/README.md
@@ -21,8 +21,7 @@ These are the sub options for the vars `ah_collections` which are dictionaries w
 |`state`|"present"|no|Desired state of the resource||
 
 The `ah_configuration_async_dir` variable sets the directory to write the results file for async tasks.
-The default value is `/tmp/.ansible_async`.
-Set to `null` to use Ansible's default value.
+The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 ### Secure Logging Variables
 

--- a/roles/collection/defaults/main.yml
+++ b/roles/collection/defaults/main.yml
@@ -21,5 +21,5 @@ ah_collections: []
 ah_configuration_collection_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_collection_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_collection_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/collection/meta/argument_specs.yml
+++ b/roles/collection/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_collection_secure_logging:

--- a/roles/dispatch/README.md
+++ b/roles/dispatch/README.md
@@ -41,8 +41,7 @@ Each item within the variable has three elements:
 If the functionality of Automation Hub is extended in the future, and more variables are able to trigger a role, the new variable should be added into the `var` list for the role above.
 
 The `ah_configuration_async_dir` variable sets the directory to write the results file for async tasks.
-The default value is `/tmp/.ansible_async`.
-Set to `null` to use Ansible's default value.
+The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 ### Authentication
 

--- a/roles/ee_image/README.md
+++ b/roles/ee_image/README.md
@@ -14,7 +14,7 @@ An Ansible Role to create execution environment images in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_images`|`see below`|yes|Data structure describing your execution environment images, described below.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_image/defaults/main.yml
+++ b/roles/ee_image/defaults/main.yml
@@ -22,5 +22,5 @@ ah_ee_images: []
 ah_configuration_ee_image_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_image_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_image_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/ee_image/meta/argument_specs.yml
+++ b/roles/ee_image/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_ee_image_secure_logging:

--- a/roles/ee_namespace/README.md
+++ b/roles/ee_namespace/README.md
@@ -15,7 +15,7 @@ This was depreciated with AAP 2.4 and Galaxy NG 4.6.3+, and removed from the API
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_namespaces`|`see below`|yes|Data structure describing your ee_namespaces, described below.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_namespace/defaults/main.yml
+++ b/roles/ee_namespace/defaults/main.yml
@@ -20,5 +20,5 @@ ah_ee_namespaces: []
 ah_configuration_ee_namespace_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_namespace_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_namespace_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/ee_namespace/meta/argument_specs.yml
+++ b/roles/ee_namespace/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_ee_namespace_secure_logging:

--- a/roles/ee_registry/README.md
+++ b/roles/ee_registry/README.md
@@ -17,7 +17,7 @@ An Ansible Role to create EE Registries in Automation Hub.
 |`proxy_username`|""|no|str|The username for the proxy authentication|
 |`proxy_password`|""|no|str|The password for the proxy authentication|
 |`ah_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_registry/defaults/main.yml
+++ b/roles/ee_registry/defaults/main.yml
@@ -26,5 +26,5 @@ ah_ee_registries: []
 ah_configuration_ee_registry_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_registry_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_registry_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/ee_registry/meta/argument_specs.yml
+++ b/roles/ee_registry/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_ee_registry_secure_logging:

--- a/roles/ee_registry_index/README.md
+++ b/roles/ee_registry_index/README.md
@@ -14,7 +14,7 @@ An Ansible Role to index EE Registries in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below. (Note this is the same as for the `ee_registries` role and the variable can be combined). Note that this role will only do anything if the `index` suboption of this variable is set to true.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_registry_index/defaults/main.yml
+++ b/roles/ee_registry_index/defaults/main.yml
@@ -19,5 +19,5 @@ ah_ee_registries: []
 ah_configuration_ee_registry_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_registry_index_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_registry_index_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/ee_registry_index/meta/argument_specs.yml
+++ b/roles/ee_registry_index/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_ee_registry_secure_logging:

--- a/roles/ee_registry_sync/README.md
+++ b/roles/ee_registry_sync/README.md
@@ -14,7 +14,7 @@ An Ansible Role to sync EE Registries in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_registries`|`see below`|yes|Data structure describing your ee_registries, described below. (Note this is the same as for the `ee_registries` role and the variable can be combined. Note that this role will only do anything if the `sync` suboption of this variable is set to true.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_registry_sync/defaults/main.yml
+++ b/roles/ee_registry_sync/defaults/main.yml
@@ -19,5 +19,5 @@ ah_ee_registries: []
 ah_configuration_ee_registry_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_registry_sync_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_registry_sync_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/ee_registry_sync/meta/argument_specs.yml
+++ b/roles/ee_registry_sync/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_ee_registry_secure_logging:

--- a/roles/ee_repository/README.md
+++ b/roles/ee_repository/README.md
@@ -14,7 +14,7 @@ An Ansible Role to create Repositories in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_repositories`|`see below`|yes|Data structure describing your ee_repositories, described below.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_repository/defaults/main.yml
+++ b/roles/ee_repository/defaults/main.yml
@@ -19,5 +19,5 @@ ah_ee_repositories: []
 ah_configuration_ee_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_repository_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_repository_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/ee_repository/meta/argument_specs.yml
+++ b/roles/ee_repository/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_ee_repository_secure_logging:

--- a/roles/ee_repository_sync/README.md
+++ b/roles/ee_repository_sync/README.md
@@ -14,7 +14,7 @@ An Ansible Role to sync EE Repositories in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_ee_repositories`|`see below`|yes|Data structure describing your ee_repositories, described below. (Note this is the same as for the `ee_repository` role and the variable can be combined. Note that this role will only do anything if the `sync` suboption of this variable is set to true.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/ee_repository_sync/defaults/main.yml
+++ b/roles/ee_repository_sync/defaults/main.yml
@@ -19,5 +19,5 @@ ah_ee_repositories: []
 ah_configuration_ee_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_repository_sync_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_repository_sync_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/ee_repository_sync/meta/argument_specs.yml
+++ b/roles/ee_repository_sync/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_ee_repository_secure_logging:

--- a/roles/group/README.md
+++ b/roles/group/README.md
@@ -14,7 +14,7 @@ An Ansible Role to create groups in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_groups`|`see below`|yes|Data structure describing your groups, described below.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/group/defaults/main.yml
+++ b/roles/group/defaults/main.yml
@@ -18,5 +18,5 @@ ah_groups: []
 ah_configuration_group_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_group_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_group_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/group/meta/argument_specs.yml
+++ b/roles/group/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_group_secure_logging:

--- a/roles/namespace/README.md
+++ b/roles/namespace/README.md
@@ -15,7 +15,7 @@ An Ansible Role to create Namespaces in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_namespaces`|`see below`|yes|Data structure describing your namespaces, described below.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/namespace/defaults/main.yml
+++ b/roles/namespace/defaults/main.yml
@@ -28,5 +28,5 @@ ah_namespaces: []
 ah_configuration_namespace_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_namespace_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_namespace_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/namespace/meta/argument_specs.yml
+++ b/roles/namespace/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_namespace_secure_logging:

--- a/roles/publish/README.md
+++ b/roles/publish/README.md
@@ -16,7 +16,7 @@ An Ansible Role to publish collections to Automation Hub or Galaxies.
 |`ah_configuration_working_dir`|`/var/tmp`|no|The working directory where the built artifacts live, or where the artifacts will be built.||
 |`ah_auto_approve`|`False`|no|Whether the collection will be automatically approved in Automation Hub. This will only work if the account being used has correct privileges.||
 |`ah_overwrite_existing`|`False`|no|Whether the collection will be automatically overwrite an existing collection in Automation Hub. This will only work if the account being used has correct privileges.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/publish/defaults/main.yml
+++ b/roles/publish/defaults/main.yml
@@ -25,5 +25,5 @@ ah_overwrite_existing: false
 ah_configuration_publish_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_publish_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_publish_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/publish/meta/argument_specs.yml
+++ b/roles/publish/meta/argument_specs.yml
@@ -49,9 +49,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_publish_secure_logging:

--- a/roles/repository/README.md
+++ b/roles/repository/README.md
@@ -33,8 +33,7 @@ An Ansible Role to create Repositories in Automation Hub.
 |`ca_cert_path`|""|no|Path to a PEM encoded CA certificate used for authentication||
 
 The `ah_configuration_async_dir` variable sets the directory to write the results file for async tasks.
-The default value is `/tmp/.ansible_async`.
-Set to `null` to use Ansible's default value.
+The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 ### Secure Logging Variables
 

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -10,5 +10,5 @@
 ah_configuration_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_repository_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_repository_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/repository/meta/argument_specs.yml
+++ b/roles/repository/meta/argument_specs.yml
@@ -26,9 +26,9 @@ argument_specs:
 
       # Async variables
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_repository_secure_logging:

--- a/roles/repository_sync/README.md
+++ b/roles/repository_sync/README.md
@@ -14,8 +14,7 @@ An Ansible Role to sync Repositories in Automation Hub.
 |`timeout`|""|no|If waiting for the project to update this will abort after this amount of seconds.||
 
 The `ah_configuration_async_dir` variable sets the directory to write the results file for async tasks.
-The default value is `/tmp/.ansible_async`.
-Set to `null` to use Ansible's default value.
+The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
 ### Secure Logging Variables
 

--- a/roles/repository_sync/defaults/main.yml
+++ b/roles/repository_sync/defaults/main.yml
@@ -10,5 +10,5 @@
 ah_configuration_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_repository_sync_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_repository_sync_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/repository_sync/meta/argument_specs.yml
+++ b/roles/repository_sync/meta/argument_specs.yml
@@ -14,9 +14,9 @@ argument_specs:
 
       # Async variables
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_repository_secure_logging:

--- a/roles/role/README.md
+++ b/roles/role/README.md
@@ -14,7 +14,7 @@ An Ansible Role to create role permisions in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_roles`|`see below`|yes|Data structure describing your role permisions, described below.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/role/defaults/main.yml
+++ b/roles/role/defaults/main.yml
@@ -18,5 +18,5 @@ ah_roles: []
 ah_configuration_role_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_role_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_role_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/role/meta/argument_specs.yml
+++ b/roles/role/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_role_secure_logging:

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -14,7 +14,7 @@ An Ansible Role to create execution environment images in Automation Hub.
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
 |`ah_users`|`see below`|yes|Data structure describing your execution environment images, described below.||
-|`ah_configuration_async_dir`|`/tmp/.ansible_async`|no|Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.||
+|`ah_configuration_async_dir`|`null`|no|Sets the directory to write the results file for async tasks. The default value is set to `null` which uses the Ansible Default of `/root/.ansible_async/`.||
 
 ### Secure Logging Variables
 

--- a/roles/user/defaults/main.yml
+++ b/roles/user/defaults/main.yml
@@ -24,5 +24,5 @@ ah_users: []
 ah_configuration_user_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_user_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_user_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
-ah_configuration_async_dir: /tmp/.ansible_async
+ah_configuration_async_dir: null
 ...

--- a/roles/user/meta/argument_specs.yml
+++ b/roles/user/meta/argument_specs.yml
@@ -28,9 +28,9 @@ argument_specs:
         required: false
         description: This variable sets delay between retries across all roles as a default.
       ah_configuration_async_dir:
-        default: /tmp/.ansible_async
+        default: null
         required: false
-        description: Sets the directory to write the results file for async tasks. Set to `null` to use Ansible's default value.
+        description: Sets the directory to write the results file for async tasks. The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
       # No_log variables
       ah_configuration_user_secure_logging:

--- a/tests/playbooks/ah_configs/ah_repository.yml
+++ b/tests/playbooks/ah_configs/ah_repository.yml
@@ -1,7 +1,7 @@
 ---
 ah_repositories:
   - name: community
-    url: https://galaxy.ansible.com/api/
+    url: https://beta-galaxy.ansible.com/
     requirements:
       - name: infra.ee_utilities
       - name: infra.controller_configuration

--- a/tests/playbooks/ah_configs/ah_repository.yml
+++ b/tests/playbooks/ah_configs/ah_repository.yml
@@ -1,4 +1,6 @@
 ---
+ah_configuration_repository_sync_async_delay: 5
+ah_configuration_repository_sync_async_retries: 150
 ah_repositories:
   - name: community
     url: https://beta-galaxy.ansible.com/

--- a/tests/playbooks/testing_playbook_ee_repository.yml
+++ b/tests/playbooks/testing_playbook_ee_repository.yml
@@ -78,6 +78,7 @@
     - name: Registery Index
       ansible.builtin.include_role:
         name: ee_registry_index
+      when: galaxy_ng_version != "master"  # https://issues.redhat.com/browse/AAH-2607
 
     # Disabled
     #    - name: Registery sync


### PR DESCRIPTION
# What does this PR do?
This PR fixes two tests and sets the async dir to the ansible default. We used tmp as at the time there was an error in the way EE's were being used, so this brings it back to standard

# How should this be tested?

Tests
