### PR TITLE
feat: add filetree_read role for automation hub

### DIFF
--- a/roles/filetree_read/defaults/main.yml
+++ b/roles/filetree_read/defaults/main.yml
@@ -1,0 +1,49 @@
+---
+
+dir_ah_filetree_vars: ah_filetree_vars
+env: dev
+ah_configuration_filetree_read_secure_logging: "{{ ah_configuration_secure_logging | default(true) }}"
+
+# Automation Hub lists
+ah_collections: []
+ah_collection_remotes: []
+ah_collection_repositories: []
+ah_ee_images: []
+ah_ee_registries: []
+ah_ee_repositories: []
+ah_groups: []
+ah_group_roles: []
+ah_namespaces: []
+ah_repositories: []
+ah_roles: []
+ah_users: []
+
+# Automation Hub Directory Path
+filetree_ah_collections: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_collections.d/"
+filetree_ah_collection_remotes: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_collection_remotes.d/"
+filetree_ah_collection_repositories: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_collection_repositories.d/"
+filetree_ah_ee_images: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_ee_images.d/"
+filetree_ah_ee_registries: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_ee_registries.d/"
+filetree_ah_ee_repositories: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_ee_repositories.d/"
+filetree_ah_groups: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_groups.d/"
+filetree_ah_group_roles: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_group_roles.d/"
+filetree_ah_namespaces: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_namespaces.d/"
+filetree_ah_repositories: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_repositories.d/"
+filetree_ah_roles: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_roles.d/"
+filetree_ah_users: "{{ dir_ah_filetree_vars }}/env/{{ env }}/ah_users.d/"
+
+# ah_filetree_read tasks order and name
+ah_configuration_filetree_read_tasks:
+  - {name: collections, var: ah_collections, tags: collections}
+  - {name: collection_remotes, var: ah_collection_remotes, tags: collection_remotes}
+  - {name: collection_repositories, var: ah_collection_repositories, tags: collection_repositories}
+  - {name: ee_images, var: ah_ee_images, tags: ee_images}
+  - {name: ee_registries, var: ah_ee_registries, tags: ee_registries}
+  - {name: ee_repositories, var: ah_ee_repositories, tags: ee_repositories}
+  - {name: groups, var: ah_groups, tags: groups}
+  - {name: group_roles, var: ah_group_roles, tags: group_roles}
+  - {name: namespaces, var: ah_namespaces, tags: namespaces}
+  - {name: repositories, var: ah_repositories, tags: repositories}
+  - {name: roles, var: ah_roles, tags: roles}
+  - {name: users, var: ah_users, tags: users}
+...

--- a/roles/filetree_read/tasks/collection_remotes.yml
+++ b/roles/filetree_read/tasks/collection_remotes.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_collections }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_collection_remotes }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_collection_remotes
+
+- name: "Read ah_collection_remotes definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_collection_remotes_definitions_item.path }}"
+  loop: "{{ __list_files_ah_collection_remotes.files }}"
+  loop_control:
+    loop_var: __read_collection_remotes_definitions_item
+  register: __contents_filetree_ah_collection_remotes
+
+- name: "Populate ah_collections list"
+  ansible.builtin.set_fact:
+    __populate_ah_collection_remotes: "{{ (__populate_ah_collection_remotes | default([])) + __populate_collection_remotes_list_item.ansible_facts.ah_collection_remotes }}"  # noqa: yaml[line-length]
+  loop: "{{ __contents_filetree_ah_collection_remotes.results }}"
+  loop_control:
+    loop_var: __populate_collection_remotes_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_collection_remotes.results is defined and __populate_collection_remotes_list_item.ansible_facts.ah_collection_remotes is defined
+
+- name: "Set ah_collection_remotes Data Structure"
+  ansible.builtin.set_fact:
+    ah_collection_remotes: "{{ __populate_ah_collection_remotes }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_collection_remotes is defined
+...

--- a/roles/filetree_read/tasks/collection_repositories.yml
+++ b/roles/filetree_read/tasks/collection_repositories.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_collection_repositories }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_collection_repositories }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_collection_repositories
+
+- name: "Read ah_collection_repositories definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_collection_repositories_definitions_item.path }}"
+  loop: "{{ __list_files_ah_collection_repositories.files }}"
+  loop_control:
+    loop_var: __read_collection_repositories_definitions_item
+  register: __contents_filetree_ah_collection_repositories
+
+- name: "Populate ah_collection_repositories list"
+  ansible.builtin.set_fact:
+    __populate_ah_collection_repositories: "{{ (__populate_ah_collection_repositories | default([])) + __populate_collection_repositories_list_item.ansible_facts.ah_collection_repositories }}"  # noqa: yaml[line-length]
+  loop: "{{ __contents_filetree_ah_collection_repositories.results }}"
+  loop_control:
+    loop_var: __populate_collection_repositories_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_collection_repositories.results is defined and __populate_collection_repositories_list_item.ansible_facts.ah_collection_repositories is defined  # noqa: yaml[line-length]
+
+- name: "Set ah_collection_repositories Data Structure"
+  ansible.builtin.set_fact:
+    ah_collection_repositories: "{{ __populate_ah_collection_repositories }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_collection_repositories is defined
+...

--- a/roles/filetree_read/tasks/collections.yml
+++ b/roles/filetree_read/tasks/collections.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_collections }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_collections }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_collections
+
+- name: "Read ah_collections definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_collections_definitions_item.path }}"
+  loop: "{{ __list_files_ah_collections.files }}"
+  loop_control:
+    loop_var: __read_collections_definitions_item
+  register: __contents_filetree_ah_collections
+
+- name: "Populate ah_collections list"
+  ansible.builtin.set_fact:
+    __populate_ah_collections: "{{ (__populate_ah_collections | default([])) + __populate_collections_list_item.ansible_facts.ah_collections }}"
+  loop: "{{ __contents_filetree_ah_collections.results }}"
+  loop_control:
+    loop_var: __populate_collections_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_collections.results is defined and __populate_collections_list_item.ansible_facts.ah_collections is defined
+
+- name: "Set ah_collections Data Structure"
+  ansible.builtin.set_fact:
+    ah_collections: "{{ __populate_ah_collections }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_collections is defined
+...

--- a/roles/filetree_read/tasks/ee_images.yml
+++ b/roles/filetree_read/tasks/ee_images.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_ee_images }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_ee_images }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_ee_images
+
+- name: "Read ah_ee_images definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_ee_images_definitions_item.path }}"
+  loop: "{{ __list_files_ah_ee_images.files }}"
+  loop_control:
+    loop_var: __read_ee_images_definitions_item
+  register: __contents_filetree_ah_ee_images
+
+- name: "Populate ah_ee_images list"
+  ansible.builtin.set_fact:
+    __populate_ah_ee_images: "{{ (__populate_ah_ee_images | default([])) + __populate_ee_images_list_item.ansible_facts.ah_ee_images }}"
+  loop: "{{ __contents_filetree_ah_ee_images.results }}"
+  loop_control:
+    loop_var: __populate_ee_images_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_ee_images.results is defined and __populate_ee_images_list_item.ansible_facts.ah_ee_images is defined
+
+- name: "Set ah_ee_images Data Structure"
+  ansible.builtin.set_fact:
+    ah_ee_images: "{{ __populate_ah_ee_images }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_ee_images is defined
+...

--- a/roles/filetree_read/tasks/ee_registries.yml
+++ b/roles/filetree_read/tasks/ee_registries.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_ee_registries }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_ee_registries }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_ee_registries
+
+- name: "Read ah_ee_registries definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_ee_registries_definitions_item.path }}"
+  loop: "{{ __list_files_ah_ee_registries.files }}"
+  loop_control:
+    loop_var: __read_ee_registries_definitions_item
+  register: __contents_filetree_ah_ee_registries
+
+- name: "Populate ah_ee_registries list"
+  ansible.builtin.set_fact:
+    __populate_ah_ee_registries: "{{ (__populate_ah_ee_registries | default([])) + __populate_ee_registries_list_item.ansible_facts.ah_ee_registries }}"
+  loop: "{{ __contents_filetree_ah_ee_registries.results }}"
+  loop_control:
+    loop_var: __populate_ee_registries_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_ee_registries.results is defined and __populate_ee_registries_list_item.ansible_facts.ah_ee_registries is defined
+
+- name: "Set ah_ee_registries Data Structure"
+  ansible.builtin.set_fact:
+    ah_ee_registries: "{{ __populate_ah_ee_registries }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_ee_registries is defined
+...

--- a/roles/filetree_read/tasks/ee_repositories.yml
+++ b/roles/filetree_read/tasks/ee_repositories.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_ee_repositories }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_ee_repositories }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_ee_repositories
+
+- name: "Read ah_ee_repositories definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_ee_repositories_definitions_item.path }}"
+  loop: "{{ __list_files_ah_ee_repositories.files }}"
+  loop_control:
+    loop_var: __read_ee_repositories_definitions_item
+  register: __contents_filetree_ah_ee_repositories
+
+- name: "Populate ah_ee_repositories list"
+  ansible.builtin.set_fact:
+    __populate_ah_ee_repositories: "{{ (__populate_ah_ee_repositories | default([])) + __populate_ee_repositories_list_item.ansible_facts.ah_ee_repositories }}"
+  loop: "{{ __contents_filetree_ah_ee_repositories.results }}"
+  loop_control:
+    loop_var: __populate_ee_repositories_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_ee_repositories.results is defined and __populate_ee_repositories_list_item.ansible_facts.ah_ee_repositories is defined
+
+- name: "Set ah_ee_repositories Data Structure"
+  ansible.builtin.set_fact:
+    ah_ee_repositories: "{{ __populate_ah_ee_repositories }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_ee_repositories is defined
+...

--- a/roles/filetree_read/tasks/group_roles.yml
+++ b/roles/filetree_read/tasks/group_roles.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_group_roles }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_group_roles }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_group_roles
+
+- name: "Read ah_group_roles definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_group_rules_definitions_item.path }}"
+  loop: "{{ __list_files_ah_group_roles.files }}"
+  loop_control:
+    loop_var: __read_group_rules_definitions_item
+  register: __contents_filetree_ah_group_roles
+
+- name: "Populate ah_group_roles list"
+  ansible.builtin.set_fact:
+    __populate_ah_group_roles: "{{ (__populate_ah_group_roles | default([])) + __populate_group_rules_list_item.ansible_facts.ah_group_roles }}"
+  loop: "{{ __contents_filetree_ah_group_roles.results }}"
+  loop_control:
+    loop_var: __populate_group_rules_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_group_roles.results is defined and __populate_group_rules_list_item.ansible_facts.ah_group_roles is defined
+
+- name: "Set ah_group_roles Data Structure"
+  ansible.builtin.set_fact:
+    ah_group_roles: "{{ __populate_ah_group_roles }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_group_roles is defined
+...

--- a/roles/filetree_read/tasks/groups.yml
+++ b/roles/filetree_read/tasks/groups.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_groups }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_groups }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_groups
+
+- name: "Read ah_groups definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_groups_definitions_item.path }}"
+  loop: "{{ __list_files_ah_groups.files }}"
+  loop_control:
+    loop_var: __read_groups_definitions_item
+  register: __contents_filetree_ah_groups
+
+- name: "Populate ah_groups list"
+  ansible.builtin.set_fact:
+    __populate_ah_groups: "{{ (__populate_ah_groups | default([])) + __populate_groups_list_item.ansible_facts.ah_groups }}"
+  loop: "{{ __contents_filetree_ah_groups.results }}"
+  loop_control:
+    loop_var: __populate_groups_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_groups.results is defined and __populate_groups_list_item.ansible_facts.ah_groups is defined
+
+- name: "Set ah_groups Data Structure"
+  ansible.builtin.set_fact:
+    ah_groups: "{{ __populate_ah_groups }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_groups is defined
+...

--- a/roles/filetree_read/tasks/main.yml
+++ b/roles/filetree_read/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+# tasks file for ah_filetree_read
+- name: "Init ah configuration variables"
+  ansible.builtin.set_fact:
+    ah_collections: []
+    ah_collection_remotes: []
+    ah_collection_repositories: []
+    ah_ee_images: []
+    ah_ee_registries: []
+    ah_ee_repositories: []
+    ah_groups: []
+    ah_group_roles: []
+    ah_namespaces: []
+    ah_repositories: []
+    ah_roles: []
+    ah_users: []
+  tags: always
+
+- name: "Include Tasks to config {{ __task_ah_filetree_read.name }}"
+  ansible.builtin.include_tasks: "{{ __task_ah_filetree_read.name }}.yml"
+  args:
+    apply:
+      tags: "{{ __task_ah_filetree_read.tags }}"
+  tags: always
+  loop: "{{ ah_configuration_filetree_read_tasks }}"
+  loop_control:
+    loop_var: __task_ah_filetree_read
+...

--- a/roles/filetree_read/tasks/namespaces.yml
+++ b/roles/filetree_read/tasks/namespaces.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_namespaces }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_namespaces }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_namespaces
+
+- name: "Read ah_namespaces definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_namespaces_definitions_item.path }}"
+  loop: "{{ __list_files_ah_namespaces.files }}"
+  loop_control:
+    loop_var: __read_namespaces_definitions_item
+  register: __contents_filetree_ah_namespaces
+
+- name: "Populate ah_namespaces list"
+  ansible.builtin.set_fact:
+    __populate_ah_namespaces: "{{ (__populate_ah_namespaces | default([])) + __populate_namespaces_list_item.ansible_facts.ah_namespaces }}"
+  loop: "{{ __contents_filetree_ah_namespaces.results }}"
+  loop_control:
+    loop_var: __populate_namespaces_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_namespaces.results is defined and __populate_namespaces_list_item.ansible_facts.ah_namespaces is defined
+
+- name: "Set ah_namespaces Data Structure"
+  ansible.builtin.set_fact:
+    ah_namespaces: "{{ __populate_ah_namespaces }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_namespaces is defined
+...

--- a/roles/filetree_read/tasks/repositories.yml
+++ b/roles/filetree_read/tasks/repositories.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_repositories }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_repositories }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_repositories
+
+- name: "Read ah_repositories definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_repositories_definitions_item.path }}"
+  loop: "{{ __list_files_ah_repositories.files }}"
+  loop_control:
+    loop_var: __read_repositories_definitions_item
+  register: __contents_filetree_ah_repositories
+
+- name: "Populate ah_repositories list"
+  ansible.builtin.set_fact:
+    __populate_ah_repositories: "{{ (__populate_ah_repositories | default([])) + __populate_repositories_list_item.ansible_facts.ah_repositories }}"
+  loop: "{{ __contents_filetree_ah_repositories.results }}"
+  loop_control:
+    loop_var: __populate_repositories_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_repositories.results is defined and __populate_repositories_list_item.ansible_facts.ah_repositories is defined
+
+- name: "Set ah_repositories Data Structure"
+  ansible.builtin.set_fact:
+    ah_repositories: "{{ __populate_ah_repositories }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_repositories is defined
+...

--- a/roles/filetree_read/tasks/roles.yml
+++ b/roles/filetree_read/tasks/roles.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_roles }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_roles }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_roles
+
+- name: "Read ah_roles definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_roles_definitions_item.path }}"
+  loop: "{{ __list_files_ah_roles.files }}"
+  loop_control:
+    loop_var: __read_roles_definitions_item
+  register: __contents_filetree_ah_roles
+
+- name: "Populate ah_roles list"
+  ansible.builtin.set_fact:
+    __populate_ah_roles: "{{ (__populate_ah_roles | default([])) + __populate_roles_list_item.ansible_facts.ah_roles }}"
+  loop: "{{ __contents_filetree_ah_roles.results }}"
+  loop_control:
+    loop_var: __populate_roles_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_roles.results is defined and __populate_roles_list_item.ansible_facts.ah_roles is defined
+
+- name: "Set ah_roles Data Structure"
+  ansible.builtin.set_fact:
+    ah_roles: "{{ __populate_ah_roles }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_roles is defined
+...

--- a/roles/filetree_read/tasks/users.yml
+++ b/roles/filetree_read/tasks/users.yml
@@ -1,0 +1,31 @@
+---
+- name: "Get list of files inside {{ filetree_ah_users }}"
+  ansible.builtin.find:
+    paths: "{{ filetree_ah_users }}"
+    file_type: file
+    recurse: true
+  register: __list_files_ah_users
+
+- name: "Read ah_users definitions"
+  ansible.builtin.include_vars:
+    file: "{{ __read_users_definitions_item.path }}"
+  loop: "{{ __list_files_ah_users.files }}"
+  loop_control:
+    loop_var: __read_users_definitions_item
+  register: __contents_filetree_ah_users
+
+- name: "Populate ah_users list"
+  ansible.builtin.set_fact:
+    __populate_ah_users: "{{ (__populate_ah_users | default([])) + __populate_users_list_item.ansible_facts.ah_users }}"
+  loop: "{{ __contents_filetree_ah_users.results }}"
+  loop_control:
+    loop_var: __populate_users_list_item
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __contents_filetree_ah_users.results is defined and __populate_users_list_item.ansible_facts.ah_users is defined
+
+- name: "Set ah_users Data Structure"
+  ansible.builtin.set_fact:
+    ah_users: "{{ __populate_ah_users }}"
+  no_log: "{{ ah_configuration_filetree_read_secure_logging }}"
+  when: __populate_ah_users is defined
+...


### PR DESCRIPTION
# What does this PR do?
This PR adds a filetree_read role similar to https://github.com/redhat-cop/controller_configuration/tree/devel/roles/filetree_read

# TODO
- [ ] Test playbook
- [ ] README, meta, etc. 
