### PR TITLE
fix: correct variable to create namespace

### DIFF
--- a/roles/dispatch/README.md
+++ b/roles/dispatch/README.md
@@ -26,7 +26,7 @@ ah_configuration_dispatcher_roles:
   - {role: ee_registry_sync, var: [ah_ee_registries], tags: regsync}
   - {role: ee_repository, var: [ah_ee_repositories], tags: repos}
   - {role: ee_repository_sync, var: [ah_ee_repository_sync], tags: reposync}
-  - {role: namespace, var: [ah_ee_namespaces], tags: namespaces}
+  - {role: namespace, var: [ah_namespaces], tags: namespaces}
   - {role: group, var: [ah_groups], tags: groups}
   - {role: publish, var: [ah_collections], tags: publish}
   - {role: user, var: [ah_users], tags: users}

--- a/roles/dispatch/defaults/main.yml
+++ b/roles/dispatch/defaults/main.yml
@@ -2,7 +2,7 @@
 ah_configuration_dispatcher_roles:
   - {role: group, var: ah_groups, tags: groups}
   - {role: user, var: ah_users, tags: users}
-  - {role: namespace, var: ah_ee_namespaces, tags: namespaces}
+  - {role: namespace, var: ah_namespaces, tags: namespaces}
   - {role: collection, var: ah_collections, tags: collections}
   - {role: ee_repository, var: ah_ee_repositories, tags: repos}
   - {role: ee_repository_sync, var: ah_ee_repository_sync, tags: reposync}

--- a/roles/dispatch/meta/argument_specs.yml
+++ b/roles/dispatch/meta/argument_specs.yml
@@ -23,7 +23,7 @@ argument_specs:
         default:
           - {role: group, var: ah_groups, tags: groups}
           - {role: user, var: ah_users, tags: users}
-          - {role: namespace, var: ah_ee_namespaces, tags: namespaces}
+          - {role: namespace, var: ah_namespaces, tags: namespaces}
           - {role: collection, var: ah_collections, tags: collections}
           - {role: ee_repository, var: ah_ee_repositories, tags: repos}
           - {role: ee_repository_sync, var: ah_ee_repository_sync, tags: reposync}


### PR DESCRIPTION
Currently the dispatch role tries to create collection namespaces based on the `ah_ee_namespaces` variable. The correct variable would be `ah_namespaces`. 