### PR TITLE
removed token auth from roles with modules that did not support it

### DIFF
--- a/changelogs/fragments/token_auth.yml
+++ b/changelogs/fragments/token_auth.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - Removed token authentication from the following roles - collection_remote, collection_repository, collection_repository_sync. The corresponding modules did not support token authentication.
+  - Removed References in the readmes to token authentication for any module that does not support token authentication.
+  - ah_repository_sync incorrectly stated which module replaced it, It is being replaced by collection_repository_sync.
+...

--- a/plugins/modules/ah_repository_sync.py
+++ b/plugins/modules/ah_repository_sync.py
@@ -26,7 +26,7 @@ description:
       U(https://www.ansible.com/) for an overview.
 deprecated:
   why: The endpoint has been removed and is not supported in AAP 2.4 onwards. It's functionality has been replaced by collection_remote_sync.
-  alternative: collection_remote_sync
+  alternative: collection_repository_sync
   removed_in: 3.0.0
   removed_from_collection: galaxy.galaxy
 options:

--- a/roles/collection_remote/README.md
+++ b/roles/collection_remote/README.md
@@ -11,7 +11,6 @@ An Ansible Role to create a Collection Remote Repository.
 |`ah_host`|""|yes|URL to the Automation Hub or Galaxy Server. (alias: `ah_hostname`)|127.0.0.1|
 |`ah_username`|""|yes|Admin User on the Automation Hub or Galaxy Server.||
 |`ah_password`|""|yes|Automation Hub Admin User's password on the Automation Hub Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
-|`ah_token`|""|yes|Tower Admin User's token on the Automation Hub Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
@@ -108,7 +107,6 @@ ah_collection_remotes:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/collection_remote/tasks/main.yml
+++ b/roles/collection_remote/tasks/main.yml
@@ -30,7 +30,6 @@
     ah_host:                  "{{ ah_host | default(ah_hostname) }}"
     ah_username:              "{{ ah_username | default(omit) }}"
     ah_password:              "{{ ah_password | default(omit) }}"
-    ah_token:                 "{{ ah_token | default(omit) }}"
     ah_path_prefix:           "{{ ah_path_prefix | default(omit) }}"
     validate_certs:           "{{ ah_validate_certs | default(omit) }}"
     request_timeout:          "{{ ah_request_timeout | default(omit) }}"

--- a/roles/collection_repository/README.md
+++ b/roles/collection_repository/README.md
@@ -11,7 +11,6 @@ An Ansible Role to create a Collection Repository.
 |`ah_host`|""|yes|URL to the Automation Hub or Galaxy Server. (alias: `ah_hostname`)|127.0.0.1|
 |`ah_username`|""|yes|Admin User on the Automation Hub or Galaxy Server.||
 |`ah_password`|""|yes|Automation Hub Admin User's password on the Automation Hub Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
-|`ah_token`|""|yes|Tower Admin User's token on the Automation Hub Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
@@ -116,7 +115,6 @@ ah_collection_repositories:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/collection_repository/tasks/main.yml
+++ b/roles/collection_repository/tasks/main.yml
@@ -17,7 +17,6 @@
     ah_host:                  "{{ ah_host | default(ah_hostname) }}"
     ah_username:              "{{ ah_username | default(omit) }}"
     ah_password:              "{{ ah_password | default(omit) }}"
-    ah_token:                 "{{ ah_token | default(omit) }}"
     ah_path_prefix:           "{{ ah_path_prefix | default(omit) }}"
     validate_certs:           "{{ ah_validate_certs | default(omit) }}"
     request_timeout:          "{{ ah_request_timeout | default(omit) }}"

--- a/roles/collection_repository_sync/README.md
+++ b/roles/collection_repository_sync/README.md
@@ -11,7 +11,6 @@ An Ansible Role to sync a Collection Repository.
 |`ah_host`|""|yes|URL to the Automation Hub or Galaxy Server. (alias: `ah_hostname`)|127.0.0.1|
 |`ah_username`|""|yes|Admin User on the Automation Hub or Galaxy Server.||
 |`ah_password`|""|yes|Automation Hub Admin User's password on the Automation Hub Server.  This should be stored in an Ansible Vault at vars/tower-secrets.yml or elsewhere and called from a parent playbook.||
-|`ah_token`|""|yes|Tower Admin User's token on the Automation Hub Server.  This should be stored in an Ansible Vault at or elsewhere and called from a parent playbook.||
 |`ah_validate_certs`|`False`|no|Whether or not to validate the Ansible Automation Hub Server's SSL certificate.||
 |`ah_request_timeout`|`10`|no|Specify the timeout Ansible should use in requests to the Galaxy or Automation Hub host.||
 |`ah_path_prefix`|""|no|API path used to access the api. Either galaxy, automation-hub, or custom||
@@ -87,7 +86,6 @@ ah_collection_repositories:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/collection_repository_sync/tasks/main.yml
+++ b/roles/collection_repository_sync/tasks/main.yml
@@ -9,7 +9,6 @@
     ah_host:                  "{{ ah_host | default(ah_hostname) }}"
     ah_username:              "{{ ah_username | default(omit) }}"
     ah_password:              "{{ ah_password | default(omit) }}"
-    ah_token:                 "{{ ah_token | default(omit) }}"
     ah_path_prefix:           "{{ ah_path_prefix | default(omit) }}"
     validate_certs:           "{{ ah_validate_certs | default(omit) }}"
     request_timeout:          "{{ ah_request_timeout | default(omit) }}"

--- a/roles/ee_image/README.md
+++ b/roles/ee_image/README.md
@@ -85,7 +85,6 @@ ah_ee_images:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/ee_namespace/README.md
+++ b/roles/ee_namespace/README.md
@@ -83,7 +83,6 @@ ah_ee_namespaces:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/ee_registry/README.md
+++ b/roles/ee_registry/README.md
@@ -87,7 +87,6 @@ ah_ee_registries:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/ee_registry_index/README.md
+++ b/roles/ee_registry_index/README.md
@@ -83,7 +83,6 @@ ah_ee_registries:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/ee_registry_sync/README.md
+++ b/roles/ee_registry_sync/README.md
@@ -83,7 +83,6 @@ ah_ee_registries:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/ee_repository/README.md
+++ b/roles/ee_repository/README.md
@@ -85,7 +85,6 @@ ah_ee_repositories:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/ee_repository_sync/README.md
+++ b/roles/ee_repository_sync/README.md
@@ -83,7 +83,6 @@ ah_ee_repositories:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/group/README.md
+++ b/roles/group/README.md
@@ -93,7 +93,6 @@ ah_groups:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/group/tasks/main.yml
+++ b/roles/group/tasks/main.yml
@@ -9,7 +9,6 @@
     ah_host:          "{{ ah_host | default(ah_hostname) }}"
     ah_username:      "{{ ah_username | default(omit) }}"
     ah_password:      "{{ ah_password | default(omit) }}"
-    # ah_token:         "{{ ah_token | default(omit) }}"
     ah_path_prefix:   "{{ ah_path_prefix | default(omit) }}"
     validate_certs:   "{{ ah_validate_certs | default(omit) }}"
     request_timeout:  "{{ ah_request_timeout | default(omit) }}"

--- a/roles/group_roles/README.md
+++ b/roles/group_roles/README.md
@@ -133,7 +133,6 @@ ah_group_roles:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/group_roles/tasks/main.yml
+++ b/roles/group_roles/tasks/main.yml
@@ -8,7 +8,6 @@
     ah_host:          "{{ ah_host | default(ah_hostname) }}"
     ah_username:      "{{ ah_username | default(omit) }}"
     ah_password:      "{{ ah_password | default(omit) }}"
-    # ah_token:         "{{ ah_token | default(omit) }}"
     ah_path_prefix:   "{{ ah_path_prefix | default(omit) }}"
     validate_certs:   "{{ ah_validate_certs | default(omit) }}"
     request_timeout:  "{{ ah_request_timeout | default(omit) }}"

--- a/roles/role/README.md
+++ b/roles/role/README.md
@@ -105,7 +105,6 @@ ah_roles:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -93,7 +93,6 @@ ah_users:
     ah_validate_certs: false
   # Define following vars here, or in ah_configs/ah_auth.yml
   # ah_host: ansible-ah-web-svc-test-project.example.com
-  # ah_token: changeme
   pre_tasks:
     - name: Include vars from ah_configs directory
       ansible.builtin.include_vars:


### PR DESCRIPTION
# What does this PR do?

- Removed token authentication from the following roles - collection_remote, collection_repository, collection_repository_sync. The corresponding modules did not support token authentication.
- Removed References in the readmes to token authentication for any module that does not support token authentication.
- ah_repository_sync incorrectly stated which module replaced it, It is being replaced by collection_repository_sync.


# Is there a relevant Issue open for this?

 #314
 #319
 