### PR TITLE
user: Fix password type field in README

### DIFF
--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -56,7 +56,7 @@ This also speeds up the overall role.
 |`last_name`|""|no|str|User's last name.|
 |`email`|""|no|str|User's email address.|
 |`is_superuser`|false|no|bool|Whether the user is a superuser.|
-|`password`|""|no|bool|User's password as a clear string. The password must contain at least 9 characters with numbers or special characters.|
+|`password`|""|no|str|User's password as a clear string. The password must contain at least 9 characters with numbers or special characters.|
 |`state`|`present`|no|str|Desired state of the user.|
 <!-- |`new_name`|""|yes|str|Setting this option will change the existing name (looked up via the name field.| -->
 


### PR DESCRIPTION
The `password` type was set to bool instead of str.