### PR TITLE
collection_remote: set sync_dependencies default to PAH default

### DIFF
--- a/plugins/modules/collection_remote.py
+++ b/plugins/modules/collection_remote.py
@@ -127,7 +127,7 @@ options:
     description:
       - Whether to download depenencies when syncing collections.
     type: bool
-    default: False
+    default: True
   proxy_url:
     description:
       - Proxy URL to use for the connection
@@ -202,7 +202,7 @@ def main():
         max_retries=dict(type='int', default=0),
         rate_limit=dict(type='int', default=8),
         signed_only=dict(type="bool", default=False),
-        sync_dependencies=dict(type="bool", default=False),
+        sync_dependencies=dict(type="bool", default=True),
         proxy_url=dict(),
         proxy_username=dict(),
         proxy_password=dict(no_log=True),

--- a/roles/collection_remote/README.md
+++ b/roles/collection_remote/README.md
@@ -73,7 +73,7 @@ This also speeds up the overall role.
 |`max_retries`|`0`|no|Retries to use when running sync. Default is 0 which does not limit.||
 |`rate_limit`|`8`|no|Limits total download rate in requests per second.||
 |`signed_only`|`False`|no|Only download signed collections|False|
-|`sync_dependencies`|`False`|no|Whether to download depenencies when syncing collections.|False|
+|`sync_dependencies`|`True`|no|Whether to download depenencies when syncing collections.|False|
 |`proxy_url`|``|no|The URL for the proxy. Defaults to global `proxy_url` variable.||
 |`proxy_username`|``|no|The username for the proxy authentication. Defaults to global `proxy_username` variable.||
 |`proxy_password`|``|no|The password for the proxy authentication. Defaults to global `proxy_password` variable.||


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

The default of sync_dependencies in PAH is True. So the ah_configuration collection should also use True as the default value.