### PR TITLE
Fix typo in ah_group_roles variable

### DIFF
--- a/roles/group_roles/meta/argument_specs.yml
+++ b/roles/group_roles/meta/argument_specs.yml
@@ -3,7 +3,7 @@ argument_specs:
   main:
     short_description: An Ansible Role to create groups roles in Automation Hub.
     options:
-      ah_groups_roles:
+      ah_group_roles:
         default: []
         required: false
         description: Data structure describing your groups roles to manage.


### PR DESCRIPTION
# What does this PR do?

Fixes a minor typo in the name of the ah_group_roles variable in the arguments_spec.yml

# How should this be tested?

Use infra.ah_configuration.group_roles to configure the group roles

# Is there a relevant Issue open for this?

resolves Red Hat Internal bug: #AAP-20247
