### PR TITLE
FIX: sanity failing due to added shebang in module_utils

### DIFF
--- a/plugins/module_utils/ah_module.py
+++ b/plugins/module_utils/ah_module.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # coding: utf-8 -*-
 
 # (c) 2020, Sean Sullivan <@sean-m-sullivan>


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Removes the shebang from module_utils which causes failing sanity tests.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
CI will start passing
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
N/A
<!--- Provide a link to any open issues that describe the problem you are solving. -->


# Other Relevant info, PRs, etc
Fixes issue introduced by #370 
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
