### PR TITLE
Fix CI stack

### DIFF
--- a/.github/workflows/ci_standalone_versioned.yml
+++ b/.github/workflows/ci_standalone_versioned.yml
@@ -55,7 +55,10 @@ jobs:
         run: sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev build-essential
 
       - name: Install docker-compose
-        run: pip3 install --upgrade docker-py docker-compose
+        run: pip3 install --upgrade docker-compose
+
+      - name: Downgrade docker
+        run: pip3 install docker==6.1.3
 
       - name: collect system info
         run: whoami; id; pwd; ls -al; uname -a ; df -h .; mount ; cat /etc/issue; docker --version ; ps aux | fgrep -i docker; ls -al /var/run/containerd/containerd.sock

--- a/.github/workflows/ci_standalone_versioned.yml
+++ b/.github/workflows/ci_standalone_versioned.yml
@@ -55,7 +55,7 @@ jobs:
         run: sudo apt-get install -y libsasl2-dev python3-dev libldap2-dev libssl-dev build-essential
 
       - name: Install docker-compose
-        run: pip3 install --upgrade docker-compose
+        run: pip3 install --upgrade docker-py docker-compose
 
       - name: collect system info
         run: whoami; id; pwd; ls -al; uname -a ; df -h .; mount ; cat /etc/issue; docker --version ; ps aux | fgrep -i docker; ls -al /var/run/containerd/containerd.sock


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Attempts to fix CI - based on this SO question: https://stackoverflow.com/questions/77641240/getting-docker-compose-typeerror-kwargs-from-env-got-an-unexpected-keyword-ar 


# How should this be tested?
CI passing - You won't be able to see this on the PR however [on my fork](https://github.com/Tompage1994/ah_configuration/actions/runs/8419421670/job/23051982535) you can see it at least gets further than current (I think it will eventually fail because it might be missing a secret) but at least we get past the existing error:

```
TypeError: kwargs_from_env() got an unexpected keyword argument 'ssl_version'
```

It does build the stack but my fork isn't set up for the full CI to work.

# Is there a relevant Issue open for this?
resolves #358 

# Other Relevant info, PRs, etc
Following successful running of this (and merging #372) we should perform a release as 2.0.5 was never released as identified in #371 



