### PR TITLE
Fix of #355 - deleting a collection

### DIFF
--- a/.github/workflows/ci_standalone_versioned.yml
+++ b/.github/workflows/ci_standalone_versioned.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set environment variables
         working-directory: galaxy_ng
         run: |
-          echo "OCI_ENV_PATH=${HOME}/work/ah_configuration/ah_configuration/oci_env" >> $GITHUB_ENV
+          echo "OCI_ENV_PATH=${GITHUB_WORKSPACE}/oci_env" >> $GITHUB_ENV
           echo "COMPOSE_INTERACTIVE_NO_CLI=1" >> $GITHUB_ENV
           echo "OCI_VERBOSE=1" >> $GITHUB_ENV
           echo "GH_DUMP_LOGS=1" >> $GITHUB_ENV

--- a/changelogs/fragments/bug_collection_delete.yml
+++ b/changelogs/fragments/bug_collection_delete.yml
@@ -1,4 +1,5 @@
 ---
 bugfixes:
   - Fixed an issue where if version was not specified in ah_collection and state=absent then the module will fail
+  - Fixed an issue where if the collection version has a '-' then it would not be referenced properly from the file path
 ...

--- a/changelogs/fragments/bug_collection_delete.yml
+++ b/changelogs/fragments/bug_collection_delete.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed an issue where if version was not specified in ah_collection and state=absent then the module will fail
+...

--- a/plugins/modules/ah_collection.py
+++ b/plugins/modules/ah_collection.py
@@ -142,7 +142,7 @@ def main():
     if auto_approve:
         if version:
             pass
-        else:
+        elif path:
             version = path.split("-")[-1].replace('.tar.gz', '')
 
     # Attempt to look up an existing item based on the provided data

--- a/plugins/modules/ah_collection.py
+++ b/plugins/modules/ah_collection.py
@@ -143,7 +143,7 @@ def main():
         if version:
             pass
         elif path:
-            version = path.split("-")[-1].replace('.tar.gz', '')
+            version = "-".join(path.split("-")[2:]).replace('.tar.gz', '')
 
     # Attempt to look up an existing item based on the provided data
     if version:

--- a/tests/playbooks/ah_configs/ah_collections.yml
+++ b/tests/playbooks/ah_configs/ah_collections.yml
@@ -18,6 +18,11 @@ ah_collections_overwrite:
     timeout: 180
     overwrite_existing: true
 
+ah_collections_delete:
+  - namespace: galaxy
+    name: galaxy
+    state: absent
+
 ah_git_collections:
   - collection_name: collection_test
     git_url: https://github.com/sean-m-sullivan/collection_test

--- a/tests/playbooks/testing_collections_playbook.yml
+++ b/tests/playbooks/testing_collections_playbook.yml
@@ -62,6 +62,12 @@
       vars:
         ah_collections: "{{ ah_collections_overwrite }}"
 
+    - name: Delete Collection
+      ansible.builtin.include_role:
+        name: collection
+      vars:
+        ah_collections: "{{ ah_collections_delete }}"
+
     - name: Publish Collections
       ansible.builtin.include_role:
         name: publish


### PR DESCRIPTION
Fixed an issue where if version was not specified in ah_collection and state=absent then the module will fail

<!--- markdownlint-disable MD041 -->
# What does this PR do?

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
CI has been updated (not that it will run at the moment)

Manually:
- create a collection in AH
- Set vars as follows:
```
my_collection:
      name: galaxy
      namespace: galaxy
      path: galaxy-galaxy-1.1.1-devel.tar.gz
```
- run the following snippet

```
- name: Delete published collections
      infra.ah_configuration.ah_collection:
        name: "{{ my_collection.name }}"
        namespace: "{{ my_collection.namespace }}"
        state: absent
        ah_hostname: "{{ ah_hostname }}"
        ah_username: "{{ ah_username }}"
        ah_password: "{{ ah_password }}"
        ah_verify_ssl: "{{ ah_validate_certs }}"
```
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #355 

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
