### PR TITLE
Add ah_configuration_{..}async_timeout parameters

### DIFF
--- a/roles/collection/README.md
+++ b/roles/collection/README.md
@@ -34,6 +34,22 @@ These are the sub options for the vars `ah_collections` which are dictionaries w
 The `ah_configuration_async_dir` variable sets the directory to write the results file for async tasks.
 The default value is set to  `null` which uses the Ansible Default of `/root/.ansible_async/`.
 
+### Asynchronous Retry Variables
+
+The following Variables set asynchronous retries for the role.
+If neither of the retries or delay or retries are set, they will default to their respective defaults.
+This allows for all items to be created, then checked that the task finishes successfully.
+This also speeds up the overall role.
+
+|Variable Name|Default Value|Required|Description|
+|:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_collection_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
+|`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
+|`ah_configuration_collection_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
+|`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
+|`ah_configuration_collection_async_delay`|`ah_configuration_async_delay`|no|This sets the delay between retries for the role.|
+
 ### Secure Logging Variables
 
 The following Variables compliment each other.

--- a/roles/collection/defaults/main.yml
+++ b/roles/collection/defaults/main.yml
@@ -19,6 +19,7 @@ ah_collections: []
 # - state
 
 ah_configuration_collection_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_collection_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_collection_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_collection_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/collection/tasks/main.yml
+++ b/roles/collection/tasks/main.yml
@@ -36,7 +36,7 @@
   loop_control:
     loop_var: "__collection"
   no_log: "{{ ah_configuration_collection_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_collection_async_timeout }}"
   poll: 0
   register: __collections_job_async
   changed_when: not __collections_job_async.changed

--- a/roles/collection_remote/README.md
+++ b/roles/collection_remote/README.md
@@ -41,6 +41,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_collection_remote_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_collection_remote_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/collection_remote/defaults/main.yml
+++ b/roles/collection_remote/defaults/main.yml
@@ -8,6 +8,7 @@
 
 # These are the default variables specific to the license role
 ah_configuration_collection_remote_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_collection_remote_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_collection_remote_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_collection_remote_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/collection_remote/tasks/main.yml
+++ b/roles/collection_remote/tasks/main.yml
@@ -37,7 +37,7 @@
   loop_control:
     loop_var: "__collection_remote_item"
   no_log: "{{ ah_configuration_collection_remote_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_collection_remote_async_timeout }}"
   poll: 0
   register: __collection_remote_job_async
   changed_when: not __collection_remote_job_async.changed

--- a/roles/collection_repository/README.md
+++ b/roles/collection_repository/README.md
@@ -41,6 +41,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_collection_repository_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_collection_repository_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/collection_repository/defaults/main.yml
+++ b/roles/collection_repository/defaults/main.yml
@@ -8,6 +8,7 @@
 
 # These are the default variables specific to the license role
 ah_configuration_collection_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_collection_repository_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_collection_repository_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_collection_repository_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/collection_repository/tasks/main.yml
+++ b/roles/collection_repository/tasks/main.yml
@@ -24,7 +24,7 @@
   loop_control:
     loop_var: "__collection_repository_item"
   no_log: "{{ ah_configuration_collection_repository_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_collection_repository_async_timeout }}"
   poll: 0
   register: __collection_repository_job_async
   changed_when: not __collection_repository_job_async.changed

--- a/roles/collection_repository_sync/README.md
+++ b/roles/collection_repository_sync/README.md
@@ -41,6 +41,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_collection_repository_sync_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_collection_repository_sync_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/collection_repository_sync/defaults/main.yml
+++ b/roles/collection_repository_sync/defaults/main.yml
@@ -8,6 +8,7 @@
 
 # These are the default variables specific to the license role
 ah_configuration_collection_repository_sync_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_collection_repository_sync_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_collection_repository_sync_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_collection_repository_sync_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/collection_repository_sync/tasks/main.yml
+++ b/roles/collection_repository_sync/tasks/main.yml
@@ -16,7 +16,7 @@
   loop_control:
     loop_var: "__collection_repository_sync_item"
   no_log: "{{ ah_configuration_collection_repository_sync_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_collection_repository_sync_async_timeout }}"
   poll: 0
   register: __collection_repository_sync_job_async
   changed_when: not __collection_repository_sync_job_async.changed

--- a/roles/ee_image/README.md
+++ b/roles/ee_image/README.md
@@ -38,6 +38,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_ee_image_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_ee_image_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/ee_image/defaults/main.yml
+++ b/roles/ee_image/defaults/main.yml
@@ -20,6 +20,7 @@ ah_ee_images: []
 #      - prod1
 
 ah_configuration_ee_image_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_ee_image_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_ee_image_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_image_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/ee_image/tasks/main.yml
+++ b/roles/ee_image/tasks/main.yml
@@ -18,7 +18,7 @@
   loop_control:
     loop_var: "__ee_image_item"
   no_log: "{{ ah_configuration_ee_image_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_ee_image_async_timeout }}"
   poll: 0
   register: __ee_images_job_async
   changed_when: not __ee_images_job_async.changed

--- a/roles/ee_namespace/README.md
+++ b/roles/ee_namespace/README.md
@@ -39,6 +39,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_ee_namespace_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_ee_namespace_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/ee_namespace/defaults/main.yml
+++ b/roles/ee_namespace/defaults/main.yml
@@ -17,6 +17,7 @@ ah_ee_namespaces: []
 #      - "group1"
 #      - "group2"
 
+ah_configuration_ee_namespace_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_ee_namespace_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_namespace_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_namespace_async_delay: "{{ ah_configuration_async_delay | default(1) }}"

--- a/roles/ee_namespace/tasks/main.yml
+++ b/roles/ee_namespace/tasks/main.yml
@@ -18,7 +18,7 @@
   loop_control:
     loop_var: "__ee_namespace_item"
   no_log: "{{ ah_configuration_ee_namespace_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_ee_namespace_async_timeout }}"
   poll: 0
   register: __ee_namespaces_job_async
   changed_when: not __ee_namespaces_job_async.changed

--- a/roles/ee_registry/README.md
+++ b/roles/ee_registry/README.md
@@ -41,6 +41,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_ee_registry_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_ee_registry_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/ee_registry/defaults/main.yml
+++ b/roles/ee_registry/defaults/main.yml
@@ -24,6 +24,7 @@ ah_ee_registries: []
 #    state: present
 
 ah_configuration_ee_registry_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_ee_registry_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_ee_registry_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_registry_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/ee_registry/tasks/main.yml
+++ b/roles/ee_registry/tasks/main.yml
@@ -24,7 +24,7 @@
   loop_control:
     loop_var: "__ee_registry_item"
   no_log: "{{ ah_configuration_ee_registry_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_ee_registry_async_timeout }}"
   poll: 0
   register: __ee_registries_job_async
   changed_when: not __ee_registries_job_async.changed

--- a/roles/ee_registry_index/README.md
+++ b/roles/ee_registry_index/README.md
@@ -38,6 +38,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_ee_registry_index_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_ee_registry_index_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/ee_registry_index/defaults/main.yml
+++ b/roles/ee_registry_index/defaults/main.yml
@@ -17,6 +17,7 @@ ah_ee_registries: []
 #    timeout:
 
 ah_configuration_ee_registry_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_ee_registry_index_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_ee_registry_index_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_registry_index_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/ee_registry_index/tasks/main.yml
+++ b/roles/ee_registry_index/tasks/main.yml
@@ -18,7 +18,7 @@
     loop_var: "__ee_registry_item"
   when: __ee_registry_item.index | default(false)
   no_log: "{{ ah_configuration_ee_registry_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_ee_registry_index_async_timeout }}"
   poll: 0
   register: __ee_registry_indexes_job_async
   changed_when: not __ee_registry_indexes_job_async.changed

--- a/roles/ee_registry_sync/README.md
+++ b/roles/ee_registry_sync/README.md
@@ -38,6 +38,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_ee_repository_sync_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_ee_registry_sync_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/ee_registry_sync/defaults/main.yml
+++ b/roles/ee_registry_sync/defaults/main.yml
@@ -16,6 +16,7 @@ ah_ee_registries: []
 #    wait: true
 #    timeout:
 
+ah_configuration_ee_registry_sync_async_timeout: "{{ ah_configuration_async_timeout }}"
 ah_configuration_ee_registry_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_ee_registry_sync_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_registry_sync_async_delay: "{{ ah_configuration_async_delay | default(1) }}"

--- a/roles/ee_registry_sync/tasks/main.yml
+++ b/roles/ee_registry_sync/tasks/main.yml
@@ -18,7 +18,7 @@
     loop_var: "__ee_registry_item"
   when: __ee_registry_item.sync | default(false)
   no_log: "{{ ah_configuration_ee_registry_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_ee_registry_sync_async_timeout }}"
   poll: 0
   register: __ee_registry_syncs_job_async
   changed_when: not __ee_registry_syncs_job_async.changed

--- a/roles/ee_repository/README.md
+++ b/roles/ee_repository/README.md
@@ -38,6 +38,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_ee_repository_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_ee_repository_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/ee_repository/defaults/main.yml
+++ b/roles/ee_repository/defaults/main.yml
@@ -17,6 +17,7 @@ ah_ee_repositories: []
 #    readme_file: "readme.md"
 
 ah_configuration_ee_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_ee_repository_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_ee_repository_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_repository_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/ee_repository/tasks/main.yml
+++ b/roles/ee_repository/tasks/main.yml
@@ -22,7 +22,7 @@
   loop_control:
     loop_var: "__ee_repository_item"
   no_log: "{{ ah_configuration_ee_repository_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_ee_repository_async_timeout }}"
   poll: 0
   register: __ee_repositories_job_async
   changed_when: not __ee_repositories_job_async.changed

--- a/roles/ee_repository_sync/README.md
+++ b/roles/ee_repository_sync/README.md
@@ -38,6 +38,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_ee_repository_sync_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_ee_repository_sync_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/ee_repository_sync/defaults/main.yml
+++ b/roles/ee_repository_sync/defaults/main.yml
@@ -17,6 +17,7 @@ ah_ee_repositories: []
 #    timeout:
 
 ah_configuration_ee_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_ee_repository_sync_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_ee_repository_sync_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_ee_repository_sync_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/ee_repository_sync/tasks/main.yml
+++ b/roles/ee_repository_sync/tasks/main.yml
@@ -18,7 +18,7 @@
     loop_var: "__ee_repository_item"
   when: __ee_repository_item.sync | default(false)
   no_log: "{{ ah_configuration_ee_repository_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_ee_repository_sync_async_timeout }}"
   poll: 0
   register: __ee_repository_syncs_job_async
   changed_when: not __ee_repository_syncs_job_async.changed

--- a/roles/group/tasks/main.yml
+++ b/roles/group/tasks/main.yml
@@ -16,7 +16,7 @@
   loop_control:
     loop_var: "__group"
   no_log: "{{ ah_configuration_group_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_group_async_timeout }}"
   poll: 0
   register: __groups_job_async
   changed_when: not __groups_job_async.changed
@@ -53,7 +53,7 @@
     loop_var: "__group"
   when: __group.perms is defined
   no_log: "{{ ah_configuration_group_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_group_async_timeout }}"
   poll: 0
   register: __group_perms_job_async
   changed_when: not __group_perms_job_async.changed

--- a/roles/group_roles/README.md
+++ b/roles/group_roles/README.md
@@ -38,10 +38,12 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_group_roles_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
-|`ah_configuration_group_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
+|`ah_configuration_group_roles_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|
-|`ah_configuration_group_async_delay`|`ah_configuration_async_delay`|no|This sets the delay between retries for the role.|
+|`ah_configuration_group_roles_async_delay`|`ah_configuration_async_delay`|no|This sets the delay between retries for the role.|
 
 ## Data Structure
 

--- a/roles/group_roles/defaults/main.yml
+++ b/roles/group_roles/defaults/main.yml
@@ -13,6 +13,7 @@ ah_group_roles: []
 #  - groups
 #  - role_list
 
+ah_configuration_group_roles_async_timeout: "{{ ah_configuration_async_timeout }}"
 ah_configuration_group_roles_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_group_roles_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_group_roles_async_delay: "{{ ah_configuration_async_delay | default(1) }}"

--- a/roles/group_roles/tasks/main.yml
+++ b/roles/group_roles/tasks/main.yml
@@ -15,7 +15,7 @@
   loop_control:
     loop_var: "__group_role"
   no_log: "{{ ah_configuration_group_roles_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_group_roles_async_timeout }}"
   poll: 0
   register: __group_roles_job_async
   changed_when: not __group_roles_job_async.changed

--- a/roles/namespace/README.md
+++ b/roles/namespace/README.md
@@ -39,6 +39,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_namespace_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_namespace_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/namespace/defaults/main.yml
+++ b/roles/namespace/defaults/main.yml
@@ -26,6 +26,7 @@ ah_namespaces: []
 #          - # mandatory, choices: change_namespace, upload_to_namespace
 
 ah_configuration_namespace_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_namespace_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_namespace_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_namespace_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/namespace/tasks/main.yml
+++ b/roles/namespace/tasks/main.yml
@@ -36,7 +36,7 @@
   loop_control:
     loop_var: "__namespace_item"
   no_log: "{{ ah_configuration_namespace_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_namespace_async_timeout }}"
   poll: 0
   register: __namespaces_job_async
   changed_when: not __namespaces_job_async.changed

--- a/roles/publish/README.md
+++ b/roles/publish/README.md
@@ -43,6 +43,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_publish_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_publish_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/publish/defaults/main.yml
+++ b/roles/publish/defaults/main.yml
@@ -23,6 +23,7 @@ ah_auto_approve: false
 ah_overwrite_existing: false
 
 ah_configuration_publish_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_publish_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_publish_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_publish_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/publish/tasks/main.yml
+++ b/roles/publish/tasks/main.yml
@@ -100,7 +100,7 @@
   loop_control:
     loop_var: "__ah_collection_file"
   no_log: "{{ ah_configuration_publish_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_publish_async_timeout }}"
   poll: 0
   register: __publish_job_async
   changed_when: not __publish_job_async.changed

--- a/roles/repository/README.md
+++ b/roles/repository/README.md
@@ -43,6 +43,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_repository_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_repository_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/repository/defaults/main.yml
+++ b/roles/repository/defaults/main.yml
@@ -8,6 +8,7 @@
 
 # These are the default variables specific to the license role
 ah_configuration_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_repository_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_repository_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_repository_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -47,7 +47,7 @@
   loop_control:
     loop_var: "__repository_item"
   no_log: "{{ ah_configuration_repository_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_repository_async_timeout }}"
   poll: 0
   register: __repositories_job_async
   changed_when: not __repositories_job_async.changed

--- a/roles/repository_sync/README.md
+++ b/roles/repository_sync/README.md
@@ -43,6 +43,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_repository_sync_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_repository_sync_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/repository_sync/defaults/main.yml
+++ b/roles/repository_sync/defaults/main.yml
@@ -7,6 +7,7 @@
 # ah_validate_certs: false
 
 # These are the default variables specific to the license role
+ah_configuration_repository_sync_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_repository_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_repository_sync_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_repository_sync_async_delay: "{{ ah_configuration_async_delay | default(1) }}"

--- a/roles/repository_sync/tasks/main.yml
+++ b/roles/repository_sync/tasks/main.yml
@@ -29,7 +29,7 @@
   loop_control:
     loop_var: "__repository_item"
   no_log: "{{ ah_configuration_repository_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_repository_sync_async_timeout }}"
   poll: 0
   register: __repositories_syncs_job_async
   changed_when: not __repositories_syncs_job_async.changed

--- a/roles/role/README.md
+++ b/roles/role/README.md
@@ -38,6 +38,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_role_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_role_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/role/defaults/main.yml
+++ b/roles/role/defaults/main.yml
@@ -15,6 +15,7 @@ ah_roles: []
 #  - perms
 #  - state
 
+ah_configuration_role_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_role_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_role_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_role_async_delay: "{{ ah_configuration_async_delay | default(1) }}"

--- a/roles/role/tasks/main.yml
+++ b/roles/role/tasks/main.yml
@@ -17,7 +17,7 @@
   loop_control:
     loop_var: "__role"
   no_log: "{{ ah_configuration_role_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_role_async_timeout }}"
   poll: 0
   register: __roles_job_async
   changed_when: not __roles_job_async.changed

--- a/roles/user/README.md
+++ b/roles/user/README.md
@@ -38,6 +38,8 @@ This also speeds up the overall role.
 
 |Variable Name|Default Value|Required|Description|
 |:---:|:---:|:---:|:---:|
+|`ah_configuration_async_timeout`|1000|no|This variable sets the async timeout for the role globally.|
+|`ah_configuration_user_async_timeout`|`ah_configuration_async_timeout`|no|This variable sets the async timeout for the role.|
 |`ah_configuration_async_retries`|50|no|This variable sets the number of retries to attempt for the role globally.|
 |`ah_configuration_user_async_retries`|`ah_configuration_async_retries`|no|This variable sets the number of retries to attempt for the role.|
 |`ah_configuration_async_delay`|1|no|This sets the delay between retries for the role globally.|

--- a/roles/user/defaults/main.yml
+++ b/roles/user/defaults/main.yml
@@ -22,6 +22,7 @@ ah_users: []
 #  - state
 
 ah_configuration_user_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
+ah_configuration_user_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_user_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_user_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -23,7 +23,7 @@
   loop_control:
     loop_var: "__user"
   no_log: "{{ ah_configuration_user_secure_logging }}"
-  async: 1000
+  async: "{{ ah_configuration_user_async_timeout }}"
   poll: 0
   register: __users_job_async
   changed_when: not __users_job_async.changed


### PR DESCRIPTION
Fixes #398

Add ah_configuration_{..}async_timeout parameters to make async parameter (timeout for async tasks) configurable.