### PR TITLE
Fix to ah_collection_upload for HTTPS uploads

### DIFF
--- a/changelogs/fragments/400-collection-upload.yml
+++ b/changelogs/fragments/400-collection-upload.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed an issue where ah_collection_upload was breaking when colelcting from a URL due to generated temp filenames
+...

--- a/plugins/module_utils/ah_module.py
+++ b/plugins/module_utils/ah_module.py
@@ -731,7 +731,7 @@ class AHModule(AnsibleModule):
     def upload(self, path, endpoint, wait=True, item_type="unknown"):
         if "://" in path:
             tmppath = fetch_file(self, path)
-            path = ".".join(tmppath.split(".")[:-2]) + ".tar.gz"
+            path = path.split("/")[-1]
             os.rename(tmppath, path)
             self.add_cleanup_file(path)
         ct, body = self.prepare_multipart(path)

--- a/tests/playbooks/ah_configs/ah_ee_repositories.yml
+++ b/tests/playbooks/ah_configs/ah_ee_repositories.yml
@@ -43,7 +43,4 @@ ah_ee_repositories:
 
       * bullet 1
       * bullet 2
-  # Testing updating the repository README file from a local file
-  - name: test-namespace/ee-minimal-rhel8
-    readme_file: "{{ tempfile['path'] }}"
 ...

--- a/tests/playbooks/testing_collections_playbook.yml
+++ b/tests/playbooks/testing_collections_playbook.yml
@@ -115,6 +115,15 @@
         ah_path_prefix: "{{ ah_path_prefix }}"
         validate_certs: "{{ ah_validate_certs }}"
 
+    - name: Upload Speicifc collection to automation hub from internet
+      ah_collection_upload:
+        path: "https://galaxy.ansible.com/download/infra-leapp-1.3.0.tar.gz"
+        wait: true
+        ah_host: "{{ ah_hostname }}"
+        ah_token: "{{ ah_token }}"
+        ah_path_prefix: "{{ ah_path_prefix }}"
+        validate_certs: "{{ ah_validate_certs }}"
+
     - name: Verify setting request_timeout to high will work
       ah_namespace:
         name: to_not_work

--- a/tests/playbooks/testing_playbook_ee_repository.yml
+++ b/tests/playbooks/testing_playbook_ee_repository.yml
@@ -47,6 +47,14 @@
       ansible.builtin.include_role:
         name: ee_repository
 
+    - name: Test updating the repository README file from a local file
+      ansible.builtin.include_role:
+        name: ee_repository
+      vars:
+        ah_ee_repositories:
+          - name: test-namespace/ee-minimal-rhel8
+            readme_file: "{{ tempfile['path'] }}"
+
     - name: Repository sync
       ansible.builtin.include_role:
         name: ee_repository_sync


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
 Fixed an issue where ah_collection_upload was breaking when collecting from a URL due to generated temp filenames
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Added a test case to CI
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #400 

# Other Relevant info, PRs, etc
None
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
