### PR TITLE
Retrieve Galaxy api prefix when resource_provider is present

### DIFF
--- a/changelogs/fragments/api_prefix_with_resource_provider.yml
+++ b/changelogs/fragments/api_prefix_with_resource_provider.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Retrieves Galaxy api prefix when resource_provider is present, defaults to existing behavior.
+...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?

Retrieves Galaxy api prefix when resource_provider is present, defaults to existing behavior.

# How should this be tested?

Probably in the galaxy_ng repo by spinning up a new testing stack and running galaxy_collection test playbooks against it. 

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
None

# Other Relevant info, PRs, etc

None
