### PR TITLE
CI fix, but still failing

### DIFF
--- a/.github/workflows/ci_dab_jwt_versioned.yml
+++ b/.github/workflows/ci_dab_jwt_versioned.yml
@@ -73,7 +73,7 @@ jobs:
           mkdir $OCI_ENV_PATH/db_backup/
 
       - name: Move ci cfg to oci
-        run: mv .github/files/ci_dab_jwt.py ./galaxy_ng/dev/oci_env_integration/actions/ci_dab_gwt.py
+        run: mv .github/files/ci_dab_jwt.py ./galaxy_ng/dev/oci_env_integration/actions/ci_dab_jwt.py
 
       - name: Stand up galaxy_ng
         working-directory: galaxy_ng

--- a/changelogs/fragments/grou_async_timeout.yml
+++ b/changelogs/fragments/grou_async_timeout.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixed an issue where where default async timeout was not set in the group role
+...

--- a/roles/group/defaults/main.yml
+++ b/roles/group/defaults/main.yml
@@ -14,7 +14,7 @@ ah_groups: []
 #  - name
 #  - perms
 #  - state
-
+ah_configuration_group_async_timeout: "{{ ah_configuration_async_timeout | default(1000) }}"
 ah_configuration_group_secure_logging: "{{ ah_configuration_secure_logging | default(false) }}"
 ah_configuration_group_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_group_async_delay: "{{ ah_configuration_async_delay | default(1) }}"


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes the CI for standing up the Galaxy ng, however it is still failing, also a default was not set, and is added. 