### PR TITLE
Remove user/group testing playbook from new CI workflow

### DIFF
--- a/.github/workflows/ci_dab_jwt_versioned.yml
+++ b/.github/workflows/ci_dab_jwt_versioned.yml
@@ -79,9 +79,6 @@ jobs:
         working-directory: galaxy_ng
         run: python3 dev/oci_env_integration/actions/ci_dab_jwt.py
 
-      - name: "Perform playbook user and group management tests"
-        run: ansible-playbook tests/playbooks/testing_playbook_user.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }}
-
       - name: "Perform playbook collection tests"
         run: ansible-playbook tests/playbooks/testing_collections_playbook.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e git_repo_name=${{ github.event.repository.name }}
 

--- a/changelogs/fragments/update_new_ci_workflow.yml
+++ b/changelogs/fragments/update_new_ci_workflow.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Remove testing playbook, expected to fail, from new CI workflow. (#416).
+...


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Updates the ci_dab_jwt CI workflow with the change that is not updating for #409 . 

This PR removes the User/Group testing playbook from the ci_dab_jwt CI workflow as it is currently expected to fail.  It still appears in the workflow and causes failures, but merging this should allow #409 to be rebased and see any other failures.

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
The User/Group testing playbook should not be run in the ci_dab_jwt CI workflow, but for some reason it will still be there.
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
No
<!--- Provide a link to any open issues that describe the problem you are solving. -->

# Other Relevant info, PRs, etc
#409 

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
