### PR TITLE
Fixes issue in collection_remotes module where the requirements could not be blanked out

### DIFF
--- a/changelogs/fragments/collection_remote_requirements.yml
+++ b/changelogs/fragments/collection_remote_requirements.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - Fixes issue in collection_remotes module where the requriements could not be blanked out
+...

--- a/plugins/modules/collection_remote.py
+++ b/plugins/modules/collection_remote.py
@@ -230,9 +230,12 @@ def main():
     new_fields = {}
 
     requirements = module.params.get("requirements")
-    if requirements:
-        requirements_content = "\n  - ".join(requirements)
-        new_fields["requirements_file"] = "---\ncollections:\n  - " + requirements_content
+    if requirements is not None:
+        if len(requirements):
+            requirements_content = "\n  - ".join(requirements)
+            new_fields["requirements_file"] = "---\ncollections:\n  - " + requirements_content
+        else:
+            new_fields["requirements_file"] = None
 
     requirements_file = module.params.get("requirements_file")
     if requirements_file:


### PR DESCRIPTION
# What does this PR do?
Fixes issue where the `[]` which might be set against the requiremnets option is ignored.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Attempt to remove requirements from a remote as follows:

```
- name: Delete requirements
      infra.ah_configuration.collection_remote:
        name: test
        url: https://galaxy.ansible.com
        requirements: []
```

# Is there a relevant Issue open for this?

<!--- Provide a link to any open issues that describe the problem you are solving. -->
resolves #413 

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
