### PR TITLE
Skip group role creation for ci_dab_jwt profile

### DIFF
--- a/.github/workflows/ci_dab_jwt_versioned.yml
+++ b/.github/workflows/ci_dab_jwt_versioned.yml
@@ -87,7 +87,7 @@ jobs:
         run: ansible-playbook tests/playbooks/testing_collections_playbook.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e git_repo_name=${{ github.event.repository.name }} -e ci_workflow=ci_dab_jwt
 
       - name: "Perform collection repository tests"
-        run: ansible-playbook tests/playbooks/testing_collections_repos.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }}
+        run: ansible-playbook tests/playbooks/testing_collections_repos.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e ci_workflow=ci_dab_jwt
 
       - name: "Perform playbook repository tests"
         run: ansible-playbook tests/playbooks/testing_playbook_ee_repository.yml -vv -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e redhat_catalog_username=${{ secrets.redhat_catalog_username }} -e redhat_catalog_password=${{ secrets.redhat_catalog_password }}

--- a/tests/playbooks/testing_collections_repos.yml
+++ b/tests/playbooks/testing_collections_repos.yml
@@ -64,6 +64,9 @@
             ah_collection_repositories:
               - name: community-infra-repo
 
+    - name: Override namespaces vars ci_dab_jwt workflow
+      when: ci_workflow != "ci_dab_jwt"
+      block:
         - name: Test group role creation
           ansible.builtin.include_role:
             name: group_roles


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Adds the ci_workflow param to the testing_collections_repos.yml playbook to facilitate skipping the block that tests group role creation, which is incompatible with that profile.

The  testing_collections_repos.yml playbook should have zero failures when testing this PR locally.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Manually against the appropriate local dev stack
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
No
<!--- Provide a link to any open issues that describe the problem you are solving. -->

# Other Relevant info, PRs, etc
Continuing the theme of fixing CI errors from #409 Smaller PRs now.
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
