### PR TITLE
Fix collection uploads

### DIFF
--- a/plugins/modules/ah_collection.py
+++ b/plugins/modules/ah_collection.py
@@ -44,6 +44,12 @@ options:
         - Collection artifact file path.
         - If version is not specified, version will be derived from file name.
       type: str
+    repository:
+      description:
+        - Name of the destination collection for the repository (staging for uploads).
+      required: False
+      type: str
+      default: 'staging'
     wait:
       description:
         - Waits for the collection to be uploaded
@@ -114,6 +120,7 @@ def main():
         namespace=dict(required=True),
         name=dict(required=True),
         path=dict(),
+        repository=dict(default='staging'),
         wait=dict(type="bool", default=True),
         interval=dict(default=10.0, type="float"),
         timeout=dict(default=None, type="int"),
@@ -130,6 +137,7 @@ def main():
     namespace = module.params.get("namespace")
     name = module.params.get("name")
     path = module.params.get("path")
+    repository = module.params.get("repository")
     wait = module.params.get("wait")
     interval = module.params.get("interval")
     timeout = module.params.get("timeout")
@@ -176,7 +184,7 @@ def main():
             module.json_output["deleted"] = True
             module.wait_for_complete(module.json_output["task"])
             # Upload new collection
-            module.upload(path, "artifacts/collections", wait, item_type="collections")
+            module.upload(path, "artifacts/collections", wait, repository, item_type="collections")
             module.json_output["changed"] = True
             # Get new collection version
             existing_item = module.get_endpoint(collection_endpoint, **{"return_none_on_404": True})
@@ -187,7 +195,7 @@ def main():
                     interval=interval
                 )
         elif existing_item is None:
-            module.upload(path, "artifacts/collections", wait, item_type="collections")
+            module.upload(path, "artifacts/collections", wait, repository, item_type="collections")
             module.json_output["changed"] = True
             if auto_approve:
                 module.approve(

--- a/plugins/modules/ah_collection_upload.py
+++ b/plugins/modules/ah_collection_upload.py
@@ -31,6 +31,12 @@ options:
         - Can be a URL
       required: True
       type: str
+    repository:
+      description:
+        - Name of the collection's repository
+        - Defaults to 'staging'
+      required: False
+      type: str
     wait:
       description:
         - Wait for the collection to be uploaded.
@@ -59,6 +65,7 @@ def main():
     # Any additional arguments that are not fields of the item can be added here
     argument_spec = dict(
         path=dict(required=True),
+        repository=dict(required=False),
         wait=dict(type="bool", default=True),
     )
 
@@ -67,9 +74,10 @@ def main():
 
     # Extract our parameters
     path = module.params.get("path")
+    repository = module.params.get("repository") or "staging"
     wait = module.params.get("wait")
 
-    module.upload(path, "artifacts/collections", wait, item_type="collections")
+    module.upload(path, "artifacts/collections", wait, repository, item_type="collections")
     module.exit_json(**module.json_output)
 
 

--- a/roles/collection/tasks/main.yml
+++ b/roles/collection/tasks/main.yml
@@ -19,6 +19,7 @@
     name:                  "{{ __collection.name }}"
     version:               "{{ __collection.version | default(omit) }}"
     path:                  "{{ __collection.path | default(omit) }}"
+    repository:            "{{ __collection.repository | default(omit) }}"
     wait:                  "{{ __collection.wait | default(omit) }}"
     auto_approve:          "{{ __collection.auto_approve | default(omit) }}"
     timeout:               "{{ __collection.timeout | default(omit) }}"

--- a/tests/playbooks/testing_collections_playbook.yml
+++ b/tests/playbooks/testing_collections_playbook.yml
@@ -6,7 +6,7 @@
   collections:
     - galaxy.galaxy
   vars:
-    ah_path_prefix: 'galaxy'
+    ah_path_prefix: '/api/galaxy'
     ah_hostname: "{{ lookup('ansible.builtin.env', 'AH_HOST') }}"
     ah_username: "{{ lookup('ansible.builtin.env', 'AH_USERNAME') }}"
     ah_password: "{{ lookup('ansible.builtin.env', 'AH_PASSWORD') }}"
@@ -47,7 +47,7 @@
               - name: community_test
                 company: Community Test
                 email: user@example.com
-                avatar_url: https://github.com/ansible/awx-logos/blob/master/awx/ui/client/assets/logo-header.svg
+                avatar_url: https://github.com/ansible/awx-logos/blob/master/awx/ui/client/assets/192.png
                 description: string
                 resources: "# Community\nA Namespace test with changes"
                 links:
@@ -56,7 +56,6 @@
               - name: infra
               - name: test_namespace
               - name: galaxy
-
 
     - name: Rename namespace
       ansible.builtin.include_role:
@@ -117,16 +116,6 @@
         state: absent
         ah_host: "{{ ah_hostname }}"
         ah_token: "{{ ah_token }}"
-        ah_path_prefix: "{{ ah_path_prefix }}"
-        validate_certs: "{{ ah_validate_certs }}"
-
-    - name: Add EE Registry
-      ah_ee_registry:
-        name: myreg
-        url: https://registry.redhat.io
-        ah_host: "{{ ah_hostname }}"
-        ah_username: "{{ ah_username }}"
-        ah_password: "{{ ah_password }}"
         ah_path_prefix: "{{ ah_path_prefix }}"
         validate_certs: "{{ ah_validate_certs }}"
 


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Fixes broken collection uploads on latest master for dab/standalone and updates `ah_module` to be basic auth only to be consistent with ah_api_module. 

<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Manually or the testing collections playbook should successfully upload a collection, it will fail on the auto-approval.

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
AAP-28357

<!--- Provide a link to any open issues that describe the problem you are solving. -->

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
