### PR TITLE
Fix CI workflow issue

### DIFF
--- a/.github/workflows/ci_dab_jwt.yml
+++ b/.github/workflows/ci_dab_jwt.yml
@@ -10,10 +10,10 @@ jobs:
         galaxy_ng_version:
           # - stable-4.10
           - master
-    uses: "./.github/workflows/ci_dab_jwt_versioned.yml"
+    uses: ./.github/workflows/ci_dab_jwt_versioned.yml
     with:
       galaxy_ng_version: ${{ matrix.galaxy_ng_version }}
-      ci_workflow: "ci_dab_jwt"
+      ci_workflow: ci_dab_jwt
       gh_ref: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets:
       redhat_catalog_username: ${{ secrets.REDHAT_CATALOG_USERNAME }}

--- a/.github/workflows/ci_dab_jwt_versioned.yml
+++ b/.github/workflows/ci_dab_jwt_versioned.yml
@@ -8,6 +8,10 @@ on:
         description: The version to pull of galaxy_ng
         required: true
         type: string
+      ci_workflow:
+        description: The workflow name
+        required: true
+        type: string
       gh_ref:
         description: The ref in the repository to pull
         required: false
@@ -84,10 +88,10 @@ jobs:
         run: python3 dev/oci_env_integration/actions/ci_dab_jwt.py
 
       - name: "Perform playbook collection tests"
-        run: ansible-playbook tests/playbooks/testing_collections_playbook.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e git_repo_name=${{ github.event.repository.name }} -e ci_workflow=ci_dab_jwt
+        run: ansible-playbook tests/playbooks/testing_collections_playbook.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e git_repo_name=${{ github.event.repository.name }} -e ci_workflow=${{ inputs.ci_workflow }}
 
       - name: "Perform collection repository tests"
-        run: ansible-playbook tests/playbooks/testing_collections_repos.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e ci_workflow=ci_dab_jwt
+        run: ansible-playbook tests/playbooks/testing_collections_repos.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e ci_workflow=${{ inputs.ci_workflow }}
 
       - name: "Perform playbook repository tests"
-        run: ansible-playbook tests/playbooks/testing_playbook_ee_repository.yml -vv -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e redhat_catalog_username=${{ secrets.redhat_catalog_username }} -e redhat_catalog_password=${{ secrets.redhat_catalog_password }}
+        run: ansible-playbook tests/playbooks/testing_playbook_ee_repository.yml -vv -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e redhat_catalog_username=${{ secrets.redhat_catalog_username }} -e redhat_catalog_password=${{ secrets.redhat_catalog_password }} -e ci_workflow=${{ inputs.ci_workflow }}

--- a/.github/workflows/ci_standalone.yml
+++ b/.github/workflows/ci_standalone.yml
@@ -11,10 +11,10 @@ jobs:
           - stable-4.8
           - stable-4.9
           - master
-    uses: "./.github/workflows/ci_standalone_versioned.yml"
+    uses: ./.github/workflows/ci_standalone_versioned.yml
     with:
       galaxy_ng_version: ${{ matrix.galaxy_ng_version }}
-      ci_workflow: "ci_standalone"
+      ci_workflow: ci_standalone
       gh_ref: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets:
       redhat_catalog_username: ${{ secrets.REDHAT_CATALOG_USERNAME }}

--- a/.github/workflows/ci_standalone_versioned.yml
+++ b/.github/workflows/ci_standalone_versioned.yml
@@ -8,6 +8,10 @@ on:
         description: The version to pull of galaxy_ng
         required: true
         type: string
+      ci_workflow:
+        description: The workflow name
+        required: true
+        type: string
       gh_ref:
         description: The ref in the repository to pull
         required: false
@@ -83,13 +87,13 @@ jobs:
         run: python3 dev/oci_env_integration/actions/ci.py
 
       - name: "Perform playbook user and group management tests"
-        run: ansible-playbook tests/playbooks/testing_playbook_user.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }}
+        run: ansible-playbook tests/playbooks/testing_playbook_user.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e ci_workflow=${{ inputs.ci_workflow }}
 
       - name: "Perform playbook collection tests"
-        run: ansible-playbook tests/playbooks/testing_collections_playbook.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e git_repo_name=${{ github.event.repository.name }} -e ci_workflow=ci_standalone
+        run: ansible-playbook tests/playbooks/testing_collections_playbook.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e git_repo_name=${{ github.event.repository.name }} -e ci_workflow=${{ inputs.ci_workflow }}
 
       - name: "Perform collection repository tests"
-        run: ansible-playbook tests/playbooks/testing_collections_repos.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }}
+        run: ansible-playbook tests/playbooks/testing_collections_repos.yml -v -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e ci_workflow=${{ inputs.ci_workflow }}
 
       - name: "Perform playbook repository tests"
-        run: ansible-playbook tests/playbooks/testing_playbook_ee_repository.yml -vv -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e redhat_catalog_username=${{ secrets.redhat_catalog_username }} -e redhat_catalog_password=${{ secrets.redhat_catalog_password }}
+        run: ansible-playbook tests/playbooks/testing_playbook_ee_repository.yml -vv -e galaxy_ng_version=${{ inputs.galaxy_ng_version }} -e redhat_catalog_username=${{ secrets.redhat_catalog_username }} -e redhat_catalog_password=${{ secrets.redhat_catalog_password }} -e ci_workflow=${{ inputs.ci_workflow }}


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Get the workflows running again.  The input definitions were missing for ci_workflow in the local reusable github actions.  This PR adds them.
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
Due to the fix being in the reusable local workflow files, the ci_standalone and ci_dab_jwt workflows still won't run on this PR.  I'm opening an additional PR in a few minutes that should have the workflows running due to this PR. 

<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
No
<!--- Provide a link to any open issues that describe the problem you are solving. -->

# Other Relevant info, PRs, etc
All other PRs recently that the CI hasn't even started. :(
<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
