### PR TITLE
Fixes docker-compose error in CI workflows

### DIFF
--- a/.github/workflows/ci_dab_jwt_versioned.yml
+++ b/.github/workflows/ci_dab_jwt_versioned.yml
@@ -53,6 +53,11 @@ jobs:
           path: galaxy_ng
           ref: ${{ inputs.galaxy_ng_version }}
 
+      - name: (Linux) Install docker compose
+        run: |
+          curl -L -o /tmp/docker-compose https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-linux-x86_64
+          install /tmp/docker-compose /usr/local/bin/
+
       # Note: COMPOSE_INTERACTIVE_NO_CLI=1 is required for oci-env to work correctly when there's no interactive terminal
       - name: Set environment variables
         working-directory: galaxy_ng

--- a/.github/workflows/ci_standalone_versioned.yml
+++ b/.github/workflows/ci_standalone_versioned.yml
@@ -53,6 +53,11 @@ jobs:
           path: galaxy_ng
           ref: ${{ inputs.galaxy_ng_version }}
 
+      - name: (Linux) Install docker compose
+        run: |
+          curl -L -o /tmp/docker-compose https://github.com/docker/compose/releases/download/v2.29.1/docker-compose-linux-x86_64
+          install /tmp/docker-compose /usr/local/bin/
+
       # Note: COMPOSE_INTERACTIVE_NO_CLI=1 is required for oci-env to work correctly when there's no interactive terminal
       - name: Set environment variables
         working-directory: galaxy_ng


### PR DESCRIPTION
<!--- markdownlint-disable MD041 -->
# What does this PR do?
Installs docker-compose in the CI workflows due to Github removing it.  This will allow the CI workflows to run today, a 
<!--- Brief explanation of the code or documentation change you've made -->

# How should this be tested?
By rebasing my other open PR #425 and seeing if the workflows run
<!--- Automated tests are preferred, but not always doable - especially for infrastructure. Include commands to run your new feature, and also post-run commands to validate that it worked. (please use code blocks to format code samples) -->

# Is there a relevant Issue open for this?
No
<!--- Provide a link to any open issues that describe the problem you are solving. -->

# Other Relevant info, PRs, etc

<!--- Please provide link to other PRs that may be related (blocking, resolves, etc. etc.) -->
