### PR TITLE
fix: cleanup working directory after collection publish

### DIFF
--- a/changelogs/fragments/457-publish-cleanup.yml
+++ b/changelogs/fragments/457-publish-cleanup.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Added ah_configuration_publish_cleanup variable to the publish role to optionally remove the working directory after collection publish (default false).
+...

--- a/roles/publish/defaults/main.yml
+++ b/roles/publish/defaults/main.yml
@@ -27,4 +27,5 @@ ah_configuration_publish_async_timeout: "{{ ah_configuration_async_timeout | def
 ah_configuration_publish_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_publish_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null
+ah_configuration_publish_cleanup: true
 ...

--- a/roles/publish/defaults/main.yml
+++ b/roles/publish/defaults/main.yml
@@ -27,5 +27,5 @@ ah_configuration_publish_async_timeout: "{{ ah_configuration_async_timeout | def
 ah_configuration_publish_async_retries: "{{ ah_configuration_async_retries | default(50) }}"
 ah_configuration_publish_async_delay: "{{ ah_configuration_async_delay | default(1) }}"
 ah_configuration_async_dir: null
-ah_configuration_publish_cleanup: true
+ah_configuration_publish_cleanup: false
 ...

--- a/roles/publish/tasks/main.yml
+++ b/roles/publish/tasks/main.yml
@@ -149,5 +149,5 @@
   ansible.builtin.file:
     path: "{{ ah_configuration_working_dir }}"
     state: absent
-  when: ah_configuration_publish_cleanup | default(true)
+  when: ah_configuration_publish_cleanup | default(false)
 ...

--- a/roles/publish/tasks/main.yml
+++ b/roles/publish/tasks/main.yml
@@ -144,4 +144,10 @@
   retries: 3
   delay: 2
   until: not approval is failed
+
+- name: Cleanup working directory
+  ansible.builtin.file:
+    path: "{{ ah_configuration_working_dir }}"
+    state: absent
+  when: ah_configuration_publish_cleanup | default(true)
 ...


### PR DESCRIPTION
Fixes #377. This PR ensures that the temporary working directory (usually /var/tmp) used during collection cloning and building is removed after the publication process is complete.